### PR TITLE
Fix version script dotenv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^20.14.10",
         "@types/nunjucks": "^3.2.6",
         "@types/unzipper": "^0.10.11",
+        "dotenv": "^16.4.5",
         "ts-node": "^10.9.1",
         "tsx": "^4.16.2",
         "typescript": "^5.5.4"
@@ -965,6 +966,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer2": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "render-reports": "tsx scripts/build-reports.ts",
-    "lint:norms": "ts-node scripts/audit-norms.ts"
+    "lint:norms": "ts-node scripts/audit-norms.ts",
+    "lint:former": "tsx scripts/check_versions.ts"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.10.0",
@@ -27,6 +28,7 @@
     "@types/unzipper": "^0.10.11",
     "ts-node": "^10.9.1",
     "tsx": "^4.16.2",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "dotenv": "^16.4.5"
   }
 }

--- a/backend/scripts/check_versions.ts
+++ b/backend/scripts/check_versions.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { config as loadEnv } from 'dotenv';
+
+// Load environment variables from a .env file if present
+loadEnv();
+
+async function main() {
+  // Simple sanity check to ensure the running Node version matches package.json
+  const pkg = JSON.parse(await readFile(resolve('./package.json'), 'utf8')) as any;
+  const required: string | undefined = pkg?.engines?.node;
+  if (required && !process.version.startsWith(required.replace('^', ''))) {
+    console.error(`Expected node version ${required}, but running ${process.version}`);
+    process.exit(1);
+  }
+  console.log('Environment and versions look good.');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add missing check_versions script and call dotenv properly
- expose script via `lint:former` npm script
- ignore node_modules directories

## Testing
- `npm run lint:former`
- `npm run typecheck`
- `npm run lint:norms`


------
https://chatgpt.com/codex/tasks/task_b_68a31d5521a8832ca27c61eef3b44698