### PR TITLE
feat: map axe rules to WCAG/EN/BITV and audit norm coverage

### DIFF
--- a/backend/config/rules_mapping.json
+++ b/backend/config/rules_mapping.json
@@ -1,9 +1,77 @@
 [
-  {
-    "axeRuleId": "link-name",
-    "wcag": ["2.4.4", "4.1.2"],
-    "bitv": ["9.2.4.4", "9.4.1.2"],
-    "en": ["9.2.4.4", "9.4.1.2"],
-    "legalContext": "WCAG 2.1 A/AA; BITV 2.0; EN 301 549"
-  }
+  { "axeRuleId": "image-alt",               "wcag": ["1.1.1"],                   "bitv": ["9.1.1.1"],      "en301549": ["9.1.1.1"],      "legalContext": "WCAG 2.1 A; BITV 2.0; EN 301 549", "impactDefault": "critical" },
+  { "axeRuleId": "input-image-alt",         "wcag": ["1.1.1"],                   "bitv": ["9.1.1.1"],      "en301549": ["9.1.1.1"],      "legalContext": "Alternative Texte für Eingabebilder",                         "impactDefault": "serious" },
+  { "axeRuleId": "area-alt",                "wcag": ["1.1.1"],                   "bitv": ["9.1.1.1"],      "en301549": ["9.1.1.1"],      "legalContext": "Alt-Texte für Image-Map-Bereiche",                             "impactDefault": "serious" },
+  { "axeRuleId": "object-alt",              "wcag": ["1.1.1"],                   "bitv": ["9.1.1.1"],      "en301549": ["9.1.1.1"],      "legalContext": "Textäquivalente für <object>",                                 "impactDefault": "serious" },
+  { "axeRuleId": "image-redundant-alt",     "wcag": ["1.1.1","2.4.4"],           "bitv": ["9.1.1.1","9.2.4.4"], "en301549": ["9.1.1.1","9.2.4.4"], "legalContext": "Alternativtext nicht redundant",                         "impactDefault": "minor" },
+
+  { "axeRuleId": "document-title",          "wcag": ["2.4.2"],                   "bitv": ["9.2.4.2"],      "en301549": ["9.2.4.2"],      "legalContext": "Seitentitel vorhanden und aussagekräftig",                    "impactDefault": "serious" },
+  { "axeRuleId": "html-has-lang",           "wcag": ["3.1.1"],                   "bitv": ["9.3.1.1"],      "en301549": ["9.3.1.1"],      "legalContext": "Sprache des Dokuments angeben",                                "impactDefault": "serious" },
+  { "axeRuleId": "html-lang-valid",         "wcag": ["3.1.1"],                   "bitv": ["9.3.1.1"],      "en301549": ["9.3.1.1"],      "legalContext": "Gültiger Sprachcode",                                          "impactDefault": "minor" },
+
+  { "axeRuleId": "landmark-one-main",       "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Genau ein <main>-Bereich",                                     "impactDefault": "moderate" },
+  { "axeRuleId": "region",                  "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Seitenbereiche vollständig durch Landmarks abdecken",         "impactDefault": "moderate" },
+  { "axeRuleId": "list",                    "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Listen semantisch korrekt",                                   "impactDefault": "moderate" },
+  { "axeRuleId": "listitem",                "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Listenelemente korrekt verschachtelt",                         "impactDefault": "moderate" },
+  { "axeRuleId": "definition-list",         "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "<dl>/<dt>/<dd> korrekt nutzen",                                "impactDefault": "moderate" },
+  { "axeRuleId": "dlitem",                  "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Definitionen vollständig/korrekt",                             "impactDefault": "moderate" },
+  { "axeRuleId": "heading-order",           "wcag": ["1.3.1","2.4.6","2.4.10"],  "bitv": ["9.1.3.1","9.2.4.6","9.2.4.10"], "en301549": ["9.1.3.1","9.2.4.6","9.2.4.10"], "legalContext": "Überschriftenhierarchie", "impactDefault": "moderate" },
+  { "axeRuleId": "page-has-heading-one",    "wcag": ["1.3.1","2.4.6"],           "bitv": ["9.1.3.1","9.2.4.6"], "en301549": ["9.1.3.1","9.2.4.6"], "legalContext": "Mindestens eine Hauptüberschrift",              "impactDefault": "minor" },
+  { "axeRuleId": "empty-heading",           "wcag": ["1.3.1","2.4.6"],           "bitv": ["9.1.3.1","9.2.4.6"], "en301549": ["9.1.3.1","9.2.4.6"], "legalContext": "Leere Überschriften vermeiden",                 "impactDefault": "minor" },
+
+  { "axeRuleId": "bypass",                  "wcag": ["2.4.1"],                   "bitv": ["9.2.4.1"],      "en301549": ["9.2.4.1"],      "legalContext": "Blocküberspringen (Skip-Link/Landmarks)",                      "impactDefault": "serious" },
+  { "axeRuleId": "skip-link",               "wcag": ["2.4.1"],                   "bitv": ["9.2.4.1"],      "en301549": ["9.2.4.1"],      "legalContext": "Ziel des Skip-Links erreichbar",                               "impactDefault": "serious" },
+
+  { "axeRuleId": "color-contrast",          "wcag": ["1.4.3"],                   "bitv": ["9.1.4.3"],      "en301549": ["9.1.4.3"],      "legalContext": "Kontrast Mindestanforderung (AA)",                             "impactDefault": "serious" },
+  { "axeRuleId": "color-contrast-enhanced","wcag": ["1.4.6"],                   "bitv": ["9.1.4.6"],      "en301549": ["9.1.4.6"],      "legalContext": "Erhöhter Kontrast (AAA – optional)",                           "impactDefault": "minor" },
+  { "axeRuleId": "link-in-text-block",      "wcag": ["1.4.1"],                   "bitv": ["9.1.4.1"],      "en301549": ["9.1.4.1"],      "legalContext": "Links nicht nur durch Farbe unterscheidbar",                   "impactDefault": "moderate" },
+
+  { "axeRuleId": "meta-viewport",           "wcag": ["1.4.4"],                   "bitv": ["9.1.4.4"],      "en301549": ["9.1.4.4"],      "legalContext": "Zoom darf nicht deaktiviert sein",                             "impactDefault": "serious" },
+  { "axeRuleId": "meta-refresh",            "wcag": ["2.2.1","3.2.5"],           "bitv": ["9.2.2.1","9.3.2.5"], "en301549": ["9.2.2.1","9.3.2.5"], "legalContext": "Automatische Weiterleitung/Neuladen",           "impactDefault": "serious" },
+
+  { "axeRuleId": "tabindex",                "wcag": ["2.4.3"],                   "bitv": ["9.2.4.3"],      "en301549": ["9.2.4.3"],      "legalContext": "Tab-Reihenfolge nicht erzwingen (tabindex>0)",                 "impactDefault": "moderate" },
+  { "axeRuleId": "keyboard",                "wcag": ["2.1.1"],                   "bitv": ["9.2.1.1"],      "en301549": ["9.2.1.1"],      "legalContext": "Tastaturbedienbarkeit",                                        "impactDefault": "critical" },
+  { "axeRuleId": "scrollable-region-focusable","wcag": ["2.4.3","2.1.1"],       "bitv": ["9.2.4.3","9.2.1.1"], "en301549": ["9.2.4.3","9.2.1.1"], "legalContext": "Scrollbereiche fokussierbar",            "impactDefault": "serious" },
+
+  { "axeRuleId": "link-name",               "wcag": ["2.4.4","4.1.2"],           "bitv": ["9.2.4.4","9.4.1.2"], "en301549": ["9.2.4.4","9.4.1.2"], "legalContext": "Erkennbarer Linktext/Name",                   "impactDefault": "serious" },
+  { "axeRuleId": "button-name",             "wcag": ["4.1.2","2.5.3"],           "bitv": ["9.4.1.2","9.2.5.3"], "en301549": ["9.4.1.2","9.2.5.3"], "legalContext": "Bedienelemente benennen (Label-in-Name)",   "impactDefault": "serious" },
+  { "axeRuleId": "input-button-name",       "wcag": ["4.1.2","2.5.3"],           "bitv": ["9.4.1.2","9.2.5.3"], "en301549": ["9.4.1.2","9.2.5.3"], "legalContext": "Buttons (input[type=button], …) benennen",   "impactDefault": "serious" },
+  { "axeRuleId": "select-name",             "wcag": ["4.1.2","3.3.2"],           "bitv": ["9.4.1.2","9.3.3.2"], "en301549": ["9.4.1.2","9.3.3.2"], "legalContext": "<select> braucht zugänglichen Namen",       "impactDefault": "critical" },
+  { "axeRuleId": "label",                   "wcag": ["3.3.2","1.3.1","4.1.2"],   "bitv": ["9.3.3.2","9.1.3.1","9.4.1.2"], "en301549": ["9.3.3.2","9.1.3.1","9.4.1.2"], "legalContext": "Formularfelder benötigen Label", "impactDefault": "critical" },
+  { "axeRuleId": "label-title-only",        "wcag": ["3.3.2"],                   "bitv": ["9.3.3.2"],      "en301549": ["9.3.3.2"],      "legalContext": "Kein reines title/aria-describedby als Label",                 "impactDefault": "serious" },
+  { "axeRuleId": "label-content-name-mismatch","wcag": ["2.5.3"],               "bitv": ["9.2.5.3"],      "en301549": ["9.2.5.3"],      "legalContext": "Sichtbares Label ⊆ Accessible Name",                            "impactDefault": "moderate" },
+
+  { "axeRuleId": "frame-title",             "wcag": ["2.4.1","4.1.2"],           "bitv": ["9.2.4.1","9.4.1.2"], "en301549": ["9.2.4.1","9.4.1.2"], "legalContext": "<iframe>/<frame> mit Titel",               "impactDefault": "serious" },
+
+  { "axeRuleId": "duplicate-id",            "wcag": ["4.1.1"],                   "bitv": ["9.4.1.1"],      "en301549": ["9.4.1.1"],      "legalContext": "Eindeutige IDs",                                                "impactDefault": "serious" },
+  { "axeRuleId": "duplicate-id-aria",       "wcag": ["4.1.1","4.1.2"],           "bitv": ["9.4.1.1","9.4.1.2"], "en301549": ["9.4.1.1","9.4.1.2"], "legalContext": "ID-Referenzen eindeutig",                    "impactDefault": "serious" },
+
+  { "axeRuleId": "role-has-required-aria-props","wcag": ["4.1.2"],               "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Erforderliche ARIA-Props vorhanden",                            "impactDefault": "serious" },
+  { "axeRuleId": "role-supports-aria-props","wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Nur unterstützte ARIA-Props nutzen",                            "impactDefault": "serious" },
+  { "axeRuleId": "aria-allowed-attr",       "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Nur erlaubte ARIA-Attribute",                                   "impactDefault": "serious" },
+  { "axeRuleId": "aria-allowed-role",       "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Erlaubte Rollen für Elemente",                                  "impactDefault": "serious" },
+  { "axeRuleId": "aria-required-attr",      "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Erforderliche ARIA-Attribute gesetzt",                          "impactDefault": "serious" },
+  { "axeRuleId": "aria-required-children",  "wcag": ["1.3.1","4.1.2"],           "bitv": ["9.1.3.1","9.4.1.2"], "en301549": ["9.1.3.1","9.4.1.2"], "legalContext": "Erforderliche ARIA-Kinder vorhanden",       "impactDefault": "serious" },
+  { "axeRuleId": "aria-required-parent",    "wcag": ["1.3.1","4.1.2"],           "bitv": ["9.1.3.1","9.4.1.2"], "en301549": ["9.1.3.1","9.4.1.2"], "legalContext": "Erforderlicher ARIA-Elternkontext",         "impactDefault": "serious" },
+  { "axeRuleId": "aria-valid-attr",         "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Gültige ARIA-Attributnamen",                                     "impactDefault": "serious" },
+  { "axeRuleId": "aria-valid-attr-value",   "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Gültige ARIA-Attributwerte",                                    "impactDefault": "serious" },
+  { "axeRuleId": "aria-hidden-focus",       "wcag": ["4.1.2","2.4.3"],           "bitv": ["9.4.1.2","9.2.4.3"], "en301549": ["9.4.1.2","9.2.4.3"], "legalContext": "Fokussierbares nicht aria-hidden",          "impactDefault": "serious" },
+  { "axeRuleId": "aria-hidden-body",        "wcag": ["1.3.1","4.1.2"],           "bitv": ["9.1.3.1","9.4.1.2"], "en301549": ["9.1.3.1","9.4.1.2"], "legalContext": "Kein aria-hidden am <body>",                "impactDefault": "serious" },
+  { "axeRuleId": "aria-conditional-attr",   "wcag": ["4.1.2"],                   "bitv": ["9.4.1.2"],      "en301549": ["9.4.1.2"],      "legalContext": "Bedingte ARIA-Attribute korrekt kombinieren",                  "impactDefault": "serious" },
+  { "axeRuleId": "presentation-role-conflict","wcag": ["1.3.1","4.1.2"],         "bitv": ["9.1.3.1","9.4.1.2"], "en301549": ["9.1.3.1","9.4.1.2"], "legalContext": "role=presentation/none ohne Fokus/Kinder", "impactDefault": "serious" },
+  { "axeRuleId": "nested-interactive",      "wcag": ["1.3.1","4.1.2"],           "bitv": ["9.1.3.1","9.4.1.2"], "en301549": ["9.1.3.1","9.4.1.2"], "legalContext": "Interaktive Elemente nicht verschachteln",  "impactDefault": "moderate" },
+
+  { "axeRuleId": "server-side-image-map",   "wcag": ["1.1.1","2.4.4"],           "bitv": ["9.1.1.1","9.2.4.4"], "en301549": ["9.1.1.1","9.2.4.4"], "legalContext": "Serverseitige Image-Maps vermeiden",       "impactDefault": "moderate" },
+
+  { "axeRuleId": "td-headers-attr",         "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Tabellen-Header korrekt zuordnen (headers/id)",                "impactDefault": "moderate" },
+  { "axeRuleId": "scope-attr-valid",        "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Gültige Werte für th[scope]",                                   "impactDefault": "minor" },
+  { "axeRuleId": "empty-table-header",      "wcag": ["1.3.1"],                   "bitv": ["9.1.3.1"],      "en301549": ["9.1.3.1"],      "legalContext": "Tabellenköpfe nicht leer",                                     "impactDefault": "minor" },
+
+  { "axeRuleId": "autocomplete-valid",      "wcag": ["1.3.5"],                   "bitv": ["9.1.3.5"],      "en301549": ["9.1.3.5"],      "legalContext": "Gültige Autocomplete-Tokens",                                   "impactDefault": "minor" },
+  { "axeRuleId": "text-spacing",            "wcag": ["1.4.12"],                  "bitv": ["9.1.4.12"],     "en301549": ["9.1.4.12"],     "legalContext": "Textabstände anpassbar (CSS)",                                  "impactDefault": "minor" },
+  { "axeRuleId": "video-caption",           "wcag": ["1.2.2"],                   "bitv": ["9.1.2.2"],      "en301549": ["9.1.2.2"],      "legalContext": "Untertitel für voraufgezeichnete Videos",                      "impactDefault": "serious" },
+  { "axeRuleId": "video-description",       "wcag": ["1.2.5"],                   "bitv": ["9.1.2.5"],      "en301549": ["9.1.2.5"],      "legalContext": "Audiodeskription (AA, falls erforderlich)",                    "impactDefault": "moderate" },
+  { "axeRuleId": "blink",                   "wcag": ["2.2.2","2.3.1"],           "bitv": ["9.2.2.2","9.2.3.1"], "en301549": ["9.2.2.2","9.2.3.1"], "legalContext": "<blink> vermeiden; Bewegung steuerbar",     "impactDefault": "minor" },
+  { "axeRuleId": "marquee",                 "wcag": ["2.2.2","2.3.1"],           "bitv": ["9.2.2.2","9.2.3.1"], "en301549": ["9.2.2.2","9.2.3.1"], "legalContext": "<marquee> vermeiden; Bewegung steuerbar",   "impactDefault": "minor" },
+  { "axeRuleId": "accesskeys",              "wcag": ["2.1.1","3.2.1"],           "bitv": ["9.2.1.1","9.3.2.1"], "en301549": ["9.2.1.1","9.3.2.1"], "legalContext": "accesskey verursacht Konflikte/Überraschungen", "impactDefault": "minor" }
 ]

--- a/backend/scripts/audit-norms.ts
+++ b/backend/scripts/audit-norms.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-interface MappingEntry { axeRuleId: string; wcag?: string[]; bitv?: string[]; en?: string[]; }
+interface MappingEntry { axeRuleId: string; wcag?: string[]; bitv?: string[]; en301549?: string[]; }
 
 function fromTags(tags: string[] | undefined): string[] {
   const out: string[] = [];
@@ -17,7 +17,7 @@ function mapNorms(rule: any, mapping: Record<string, MappingEntry>, bitvMap: any
   let wcag: string[] = rule.wcagRefs || entry.wcag || [];
   if (!wcag.length) wcag = fromTags(rule.tags);
   let bitv: string[] = rule.bitvRefs || entry.bitv || [];
-  let en: string[] = rule.en301549Refs || entry.en || [];
+  let en: string[] = rule.en301549Refs || entry.en301549 || [];
   if (!bitv.length) bitv = wcag.map((w: string) => bitvMap[w] || (bitvMap._prefix ? bitvMap._prefix + w : undefined)).filter(Boolean);
   if (!en.length) en = wcag.map((w: string) => enMap[w] || (enMap._prefix ? enMap._prefix + w : undefined)).filter(Boolean);
   return { wcag, bitv, en, ok: wcag.length && bitv.length && en.length };

--- a/backend/scripts/crawl-scan.ts
+++ b/backend/scripts/crawl-scan.ts
@@ -160,13 +160,18 @@ function fromTags(tags: string[] | undefined): string[] {
 }
 function enrichViolation(v: Violation, mapping:Record<string,any>, bitvMap:any, enMap:any){
   const m = mapping[v.id] || {};
+  const hasExplicit = Boolean(mapping[v.id]);
   let wcag: string[] = v.wcagRefs || m.wcag || [];
   if (!wcag.length) wcag = fromTags(v.tags);
   let bitv: string[] = v.bitvRefs || m.bitv || [];
-  let en: string[] = v.en301549Refs || m.en || [];
+  let en: string[] = v.en301549Refs || m.en301549 || [];
   if (!bitv.length) bitv = wcag.map(w => bitvMap[w] || (bitvMap._prefix ? bitvMap._prefix + w : undefined)).filter(Boolean);
   if (!en.length) en = wcag.map(w => enMap[w] || (enMap._prefix ? enMap._prefix + w : undefined)).filter(Boolean);
-  v.wcagRefs = wcag; v.bitvRefs = bitv; v.en301549Refs = en; if (m.legalContext) v.legalContext = m.legalContext; if (wcag.length||bitv.length||en.length) v.mapped = true;
+  v.wcagRefs = wcag;
+  v.bitvRefs = bitv;
+  v.en301549Refs = en;
+  if (m.legalContext) v.legalContext = m.legalContext;
+  if (!hasExplicit && (wcag.length || bitv.length || en.length)) v.mapped = true;
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- replace rules mapping with comprehensive WCAG/BITV/EN references
- enrich scans and reports with derived norm data when mappings are missing
- add norms audit ensuring every issue has WCAG, BITV and EN references

## Testing
- `npm run typecheck`
- `npm run lint:norms` *(fails gracefully without issues.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a33642eb04832cb632e6e51732dfdc