### PR TITLE
feat: enforce normative references and audit checks

### DIFF
--- a/.github/workflows/site_scan.yml
+++ b/.github/workflows/site_scan.yml
@@ -112,6 +112,10 @@ jobs:
         run: npx tsx scripts/build-reports.ts
         working-directory: backend
 
+      - name: Audit Norm References
+        run: npm run lint:norms
+        working-directory: backend
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,9 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "render-reports": "tsx scripts/build-reports.ts",
-    "lint:norms": "ts-node scripts/audit-norms.ts",
-    "lint:former": "tsx scripts/check_versions.ts"
+    "lint:norms": "tsx scripts/audit-norms.ts",
+    "lint:former": "tsx scripts/check_versions.ts",
+    "test": "node --test --import tsx"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.10.0",

--- a/backend/scanners/downloads.ts
+++ b/backend/scanners/downloads.ts
@@ -10,6 +10,8 @@ export interface DownloadCheck {
   ok: boolean;
   checks: { name: string; passed: boolean; details?: string }[];
   note?: string;
+  legacyFormat?: boolean;
+  needsManualReview?: boolean;
 }
 
 interface Options {
@@ -43,7 +45,9 @@ export async function checkDownloads(urls: string[], opts: Options): Promise<Dow
     if (t === "doc" || t === "ppt") {
       out.push({
         url, type: t, ok: false,
-        note: "Altes Binary-Format (DOC/PPT) – automatische BITV/WCAG-Prüfung nicht möglich. Bitte konvertieren.",
+        legacyFormat: true,
+        needsManualReview: true,
+        note: "Altes Binary-Format – automatische BITV/WCAG-Prüfung nicht möglich. Bitte in DOCX/PPTX oder PDF/UA konvertieren.",
         checks: [{ name: "legacy-format", passed: false, details: "Nicht automatisch prüfbar" }],
       });
       continue;

--- a/backend/scripts/lib/norms.ts
+++ b/backend/scripts/lib/norms.ts
@@ -1,0 +1,40 @@
+export function normalizeWcagTags(tags: string[] = [], helpUrl?: string): string[] {
+  const out = new Set<string>();
+  for (const t of tags) {
+    const m = t.match(/^wcag(\d)(\d)(\d)([a-z])?$/i);
+    if (m) out.add(`${m[1]}.${m[2]}.${m[3]}${m[4] || ''}`);
+  }
+  if (helpUrl) {
+    const m = helpUrl.match(/wcag(\d)(\d)(\d)([a-z])?/i);
+    if (m) out.add(`${m[1]}.${m[2]}.${m[3]}${m[4] || ''}`);
+  }
+  return Array.from(out);
+}
+
+export function deriveBitv(wcagIds: string[]): string[] {
+  const out = new Set<string>();
+  for (const id of wcagIds) {
+    if (typeof id === 'string' && id) out.add(`9.${id}`);
+  }
+  return Array.from(out);
+}
+
+export function deriveEn(wcagIds: string[]): string[] {
+  const out = new Set<string>();
+  for (const id of wcagIds) {
+    if (typeof id === 'string' && id) out.add(`9.${id}`);
+  }
+  return Array.from(out);
+}
+
+export function enrichWithFallback(v: any) {
+  const hasW = Array.isArray(v.wcagRefs) && v.wcagRefs.length > 0;
+  const hasB = Array.isArray(v.bitvRefs) && v.bitvRefs.length > 0;
+  const hasE = Array.isArray(v.en301549Refs) && v.en301549Refs.length > 0;
+  if (hasW && hasB && hasE) return v;
+  const wcag = normalizeWcagTags(v.tags || [], v.helpUrl);
+  v.wcagRefs = wcag;
+  v.bitvRefs = deriveBitv(wcag);
+  v.en301549Refs = deriveEn(wcag);
+  return v;
+}

--- a/backend/test/audit-norms.test.ts
+++ b/backend/test/audit-norms.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const script = path.resolve('scripts/audit-norms.ts');
+
+function run(outDir: string) {
+  const res = spawnSync(process.execPath, ['--import', 'tsx', script], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, OUT_DIR: outDir },
+    encoding: 'utf-8'
+  });
+  return res;
+}
+
+test('audit-norms flags missing references', () => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'audit-'));
+  const outDir = path.join(tmp);
+  mkdirSync(outDir, { recursive: true });
+  const issues = [
+    { id: 'complete', wcagRefs: ['1.1.1'], bitvRefs: ['9.1.1.1'], en301549Refs: ['9.1.1.1'] },
+    { id: 'missing', wcagRefs: [], bitvRefs: [], en301549Refs: [] }
+  ];
+  writeFileSync(path.join(outDir, 'issues.json'), JSON.stringify(issues, null, 2));
+  const res = run(outDir);
+  assert.notStrictEqual(res.status, 0);
+  const audit = JSON.parse(readFileSync(path.join(outDir, 'norm_audit.json'), 'utf-8'));
+  assert.equal(audit.missing, 1);
+  assert.equal(audit.missingByRule.missing, 1);
+});

--- a/backend/test/e2e-sample.test.ts
+++ b/backend/test/e2e-sample.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { enrichWithFallback } from '../scripts/lib/norms.js';
+
+test('WAI BAD sample rules carry norms', async () => {
+  const mapArr = JSON.parse(await fs.readFile(path.resolve('config/rules_mapping.json'), 'utf-8'));
+  const byId: Record<string, any> = {};
+  for (const m of mapArr) {
+    byId[m.axeRuleId] = {
+      wcagRefs: m.wcagRefs || m.wcag || [],
+      bitvRefs: m.bitvRefs || m.bitv || [],
+      en301549Refs: m.en301549Refs || m.en301549 || []
+    };
+  }
+  const ids = ['select-name','label','empty-table-header','label-title-only'];
+  for (const id of ids) {
+    const v: any = { id, tags: [] };
+    const entry = byId[id];
+    if (entry) {
+      v.wcagRefs = entry.wcagRefs;
+      v.bitvRefs = entry.bitvRefs;
+      v.en301549Refs = entry.en301549Refs;
+    }
+    enrichWithFallback(v);
+    assert.ok(v.wcagRefs.length && v.bitvRefs.length && v.en301549Refs.length, `${id} should have norms`);
+  }
+});

--- a/backend/test/norms.test.ts
+++ b/backend/test/norms.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeWcagTags, deriveBitv, deriveEn } from '../scripts/lib/norms.js';
+
+test('normalizeWcagTags parses axe tags', () => {
+  const tags = ['wcag111', 'wcag131b', 'WCAG242', 'random', 'wcag2a'];
+  assert.deepStrictEqual(normalizeWcagTags(tags), ['1.1.1', '1.3.1b', '2.4.2']);
+});
+
+test('deriveBitv/en derive from wcag ids', () => {
+  const ids = ['1.1.1', '2.4.2', '3.1.1b'];
+  assert.deepStrictEqual(deriveBitv(ids), ['9.1.1.1', '9.2.4.2', '9.3.1.1b']);
+  assert.deepStrictEqual(deriveEn(ids), ['9.1.1.1', '9.2.4.2', '9.3.1.1b']);
+});


### PR DESCRIPTION
## Summary
- unify rule mapping and enrich violations with norms
- add robust fallback normalisation and audit script
- flag legacy DOC/PPT downloads and display manual-review notes
- run norms linter in CI workflow

## Testing
- `npm test`
- `npm run lint:norms`


------
https://chatgpt.com/codex/tasks/task_b_68a36aee5de8832cbd9535770332448f