### PR TITLE
chore: upgrade CI Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install deps
         run: npm install --no-audit --no-fund

--- a/.github/workflows/hello_scan.yml
+++ b/.github/workflows/hello_scan.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: npm install --no-audit --no-fund
       - name: Install Playwright

--- a/.github/workflows/site_scan.yml
+++ b/.github/workflows/site_scan.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install deps
         run: npm install --no-audit --no-fund


### PR DESCRIPTION
## Summary
- use Node.js 22 in GitHub workflows to support tsx test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a41c9b5844832cb97c17766af37293