### PR TITLE
feat: improve download type labeling

### DIFF
--- a/backend/scripts/lib/mime.ts
+++ b/backend/scripts/lib/mime.ts
@@ -1,0 +1,31 @@
+export function contentTypeToLabel(ct: string | undefined, url?: string): "PDF" | "DOCX" | "PPTX" | "XLSX" | "CSV" | "TXT" | "ODT" | "ODS" | "ODP" | "Unknown" {
+  const map: Record<string, string> = {
+    "application/pdf": "PDF",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PPTX",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "text/csv": "CSV",
+    "text/plain": "TXT",
+    "application/vnd.oasis.opendocument.text": "ODT",
+    "application/vnd.oasis.opendocument.spreadsheet": "ODS",
+    "application/vnd.oasis.opendocument.presentation": "ODP",
+  };
+  if (ct && map[ct]) return map[ct] as any;
+  if (url) {
+    const m = url.toLowerCase().match(/\.([a-z0-9]+)(?:$|\?)/);
+    const ext = m ? m[1] : "";
+    const extMap: Record<string, string> = {
+      pdf: "PDF",
+      docx: "DOCX",
+      pptx: "PPTX",
+      xlsx: "XLSX",
+      csv: "CSV",
+      txt: "TXT",
+      odt: "ODT",
+      ods: "ODS",
+      odp: "ODP",
+    };
+    if (extMap[ext]) return extMap[ext] as any;
+  }
+  return "Unknown";
+}

--- a/backend/tests/mime.test.ts
+++ b/backend/tests/mime.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { contentTypeToLabel } from '../scripts/lib/mime.js';
+
+test('maps known content types', () => {
+  assert.equal(contentTypeToLabel('application/pdf'), 'PDF');
+  assert.equal(contentTypeToLabel('application/vnd.openxmlformats-officedocument.wordprocessingml.document'), 'DOCX');
+});
+
+test('falls back to extension', () => {
+  assert.equal(contentTypeToLabel(undefined, 'https://example.com/file.pptx'), 'PPTX');
+});
+
+test('unknown types yield Unknown', () => {
+  assert.equal(contentTypeToLabel('application/x-foo', 'https://x/baz.unknown'), 'Unknown');
+});


### PR DESCRIPTION
## Summary
- map MIME types and extensions to human-readable labels
- show accurate download type counts in internal report
- add unit tests for MIME labeling

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a429748a88832ca4556fe70f92c6b0