### PR TITLE
fix: silence noisy link-in-text-block rule

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,8 @@ Ergebnis: HTML + PDF im Ordner `out/`.
 
 Der Hauptscanner `crawl-scan.ts` lässt sich über Umgebungsvariablen bzw. Flags steuern. Beispiele:
 
+> Hinweis: Die sehr umfangreiche axe-Regel `link-in-text-block` ist standardmäßig deaktiviert, um eine Flut identischer Meldungen zu vermeiden.
+
 ```bash
 START_URL=https://www.w3.org/WAI/demos/bad/ \
 RESPECT_ROBOTS=true \

--- a/backend/scripts/crawl-scan.ts
+++ b/backend/scripts/crawl-scan.ts
@@ -367,7 +367,10 @@ async function main() {
         await autoScroll(page, logInteraction, WAIT_AFTER_LOAD);
         await gentleInteractions(page, logInteraction);
 
-        const axe = new AxeBuilder({ page });
+        // "link-in-text-block" often yields an excessive number of
+        // findings on larger sites and can exceed GitHub's annotation
+        // limits. It is disabled here to keep scan results manageable.
+        const axe = new AxeBuilder({ page }).disableRules(["link-in-text-block"]);
         const res = await axe.analyze();
         const violations: Violation[] = (res.violations || []) as any[];
         const incomplete: any[] = (res.incomplete || []) as any[];


### PR DESCRIPTION
## Summary
- skip axe's `link-in-text-block` rule to avoid flooding the scan with duplicate link warnings
- document that the rule is disabled by default

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4757152e8832c81435e6fc4a566f3