### PR TITLE
feat: scaffold modular engine with base modules

### DIFF
--- a/backend/config/scan.defaults.json
+++ b/backend/config/scan.defaults.json
@@ -1,16 +1,23 @@
 {
-  "sameOriginOnly": true,
-  "respectRobotsTxt": true,
-  "seedSitemap": true,
-  "respectHashRoutes": true,
-  "checkIframes": true,
-  "consentClick": true,
-  "maxPages": 50,
-  "maxDepth": 3,
-  "timeoutMs": 45000,
-  "waitAfterLoadMs": 600,
-  "waitMinMs": 200,
-  "waitMaxMs": 600,
-  "userAgent": "AccessCheckerBot/0.2 (+https://example.invalid)",
-  "jurisdiction": "DE-TH"
+  "profile": "fast",
+  "modules": {
+    "dom-aria": true,
+    "forms": true,
+    "downloads": true,
+    "pdf": true,
+    "office": true,
+    "csv-txt": true
+  },
+  "profiles": {
+    "fast": ["dom-aria","forms","downloads","pdf","office","csv-txt"],
+    "full": ["*"]
+  },
+  "maxPages": 100,
+  "maxDepth": 5,
+  "rateLimit": 4,
+  "concurrency": 3,
+  "simulateBrowser": true,
+  "scanIframes": "same-origin",
+  "viewport": "1366x900",
+  "downloadMaxSizeMB": 25
 }

--- a/backend/config/schemas/scan.defaults.schema.json
+++ b/backend/config/schemas/scan.defaults.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "profile": { "type": "string" },
+    "modules": {
+      "type": "object",
+      "additionalProperties": { "type": "boolean" }
+    },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  },
+  "required": ["profile", "modules", "profiles"]
+}

--- a/backend/core/config.ts
+++ b/backend/core/config.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import Ajv from 'ajv';
+import { ScanConfig } from './types.js';
+
+export async function loadConfig(argv: string[] = process.argv.slice(2)): Promise<ScanConfig> {
+  const configDir = path.join(process.cwd(), 'config');
+  const defaultsPath = path.join(configDir, 'scan.defaults.json');
+  const schemaPath = path.join(configDir, 'schemas', 'scan.defaults.schema.json');
+  const defaults: ScanConfig = JSON.parse(await fs.readFile(defaultsPath, 'utf-8'));
+  const schema = JSON.parse(await fs.readFile(schemaPath, 'utf-8'));
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+  if (!validate(defaults)) {
+    throw new Error('Invalid defaults config');
+  }
+  const program = new Command();
+  program
+    .allowUnknownOption(true)
+    .option('--profile <profile>')
+    .option('--modules <modules>')
+    .option('--url <url>');
+  program.parse(argv, { from: 'user' });
+  const opts = program.opts();
+
+  const config: ScanConfig = { ...defaults };
+  if (opts.profile) config.profile = opts.profile;
+  if (opts.modules) {
+    const mods: Record<string, boolean> = {};
+    for (const m of String(opts.modules).split(',')) mods[m.trim()] = true;
+    config.modules = mods;
+  }
+  if (opts.url) config.url = opts.url;
+
+  // env overrides (e.g., PROFILE, MODULES)
+  if (process.env.PROFILE) config.profile = process.env.PROFILE;
+  if (process.env.MODULES) {
+    const mods: Record<string, boolean> = {};
+    for (const m of process.env.MODULES.split(',')) mods[m.trim()] = true;
+    config.modules = mods;
+  }
+  return config;
+}

--- a/backend/core/engine.ts
+++ b/backend/core/engine.ts
@@ -1,0 +1,72 @@
+import { chromium } from 'playwright';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { loadConfig } from './config.js';
+import { getModules } from './registry.js';
+import { ModuleContext, ModuleResult, ScanResults, Issue } from './types.js';
+
+export async function main() {
+  const config = await loadConfig();
+  const outDir = path.join(process.cwd(), 'out');
+  await fs.mkdir(outDir, { recursive: true });
+  const modules = await getModules([], config.profile, config);
+  const start = new Date();
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  if (config.url) await page.goto(config.url);
+
+  const moduleResults: Record<string, ModuleResult> = {};
+  const issues: Issue[] = [];
+
+  const ctx: ModuleContext = {
+    page,
+    url: config.url || '',
+    crawlGraph: [],
+    config,
+    log: () => {},
+    saveArtifact: async (name, data) => {
+      const file = path.join(outDir, name);
+      await fs.writeFile(file, JSON.stringify(data, null, 2));
+      return file;
+    }
+  };
+
+  for (const mod of modules) {
+    try {
+      if (mod.init) await mod.init(ctx);
+      const res = await mod.run(ctx);
+      moduleResults[mod.slug] = res;
+      issues.push(...res.findings);
+      if (mod.dispose) await mod.dispose(ctx);
+    } catch (e) {
+      ctx.log({ level: 'error', module: mod.slug, url: ctx.url, msg: String(e) });
+    }
+  }
+  await browser.close();
+  const finished = new Date();
+
+  const results: ScanResults = {
+    meta: {
+      startedAt: start.toISOString(),
+      finishedAt: finished.toISOString(),
+      target: config.url || '',
+      profile: config.profile
+    },
+    score: { overall: 0 },
+    modules: moduleResults,
+    issues,
+    pages: [{ url: config.url || '' }]
+  };
+  await fs.writeFile(path.join(outDir, 'results.json'), JSON.stringify(results, null, 2));
+  await fs.writeFile(path.join(outDir, 'issues.json'), JSON.stringify(issues, null, 2));
+  return results;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/backend/core/registry.ts
+++ b/backend/core/registry.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { Module, ScanConfig } from './types.js';
+
+const registered = new Map<string, Module>();
+
+export function register(mod: Module) {
+  registered.set(mod.slug, mod);
+}
+
+async function loadModule(slug: string): Promise<Module> {
+  if (registered.has(slug)) return registered.get(slug)!;
+  const modulesDir = path.join(process.cwd(), 'modules');
+  const ext = import.meta.url.endsWith('.ts') ? '.ts' : '.js';
+  const modPath = pathToFileURL(path.join(modulesDir, slug, `index${ext}`)).href;
+  const mod: Module = (await import(modPath)).default;
+  register(mod);
+  return mod;
+}
+
+export async function getModules(enabled: string[] = [], profile: string, config: ScanConfig): Promise<Module[]> {
+  let list: string[] = [];
+  if (enabled.length === 0) {
+    const prof = config.profiles?.[profile];
+    if (prof && prof.length) list = prof;
+    else {
+      list = Object.keys(config.modules).filter((m) => config.modules[m]);
+    }
+  } else {
+    list = enabled;
+  }
+  if (list.includes('*')) {
+    const modulesDir = path.join(process.cwd(), 'modules');
+    list = await fs.readdir(modulesDir);
+  }
+  const mods: Module[] = [];
+  for (const slug of list) {
+    try {
+      mods.push(await loadModule(slug));
+    } catch (e) {
+      // ignore missing modules
+    }
+  }
+  return mods;
+}

--- a/backend/core/types.ts
+++ b/backend/core/types.ts
@@ -1,0 +1,87 @@
+export type Severity = 'critical' | 'serious' | 'moderate' | 'minor';
+
+export interface NormRefs {
+  wcag?: string[];
+  bitv?: string[];
+  en301549?: string[];
+  legalContext?: string;
+}
+
+export interface Finding {
+  id: string;
+  module: string;
+  severity: Severity;
+  summary: string;
+  details: string;
+  selectors?: string[];
+  pageUrl: string;
+  norms?: NormRefs;
+}
+
+export interface Issue extends Finding {}
+
+export interface DownloadFinding extends Finding {
+  downloadUrl?: string;
+}
+
+export interface ModuleResult {
+  module: string;
+  version: string;
+  findings: Finding[];
+  warnings?: string[];
+  stats?: Record<string, number>;
+  artifacts?: Record<string, string>;
+}
+
+export interface PageMeta {
+  url: string;
+  [key: string]: unknown;
+}
+
+export interface ScoreSummary {
+  overall: number;
+  bySeverity?: Record<Severity, number>;
+}
+
+export interface LogEvent {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  module?: string;
+  url?: string;
+  msg: string;
+  elapsed?: number;
+}
+
+export interface ScanConfig {
+  profile: string;
+  modules: Record<string, boolean>;
+  profiles: Record<string, string[]>;
+  url?: string;
+  [key: string]: unknown;
+}
+
+export interface ModuleContext {
+  page: import('playwright').Page;
+  url: string;
+  crawlGraph: PageMeta[];
+  config: ScanConfig;
+  log: (e: LogEvent) => void;
+  saveArtifact: (name: string, data: unknown) => Promise<string>;
+}
+
+export interface Module {
+  slug: string;
+  version: string;
+  requires?: string[];
+  init?(ctx: ModuleContext): Promise<void> | void;
+  run(ctx: ModuleContext): Promise<ModuleResult>;
+  dispose?(ctx: ModuleContext): Promise<void> | void;
+}
+
+export interface ScanResults {
+  meta: { startedAt: string; finishedAt: string; target: string; profile: string };
+  score: ScoreSummary;
+  modules: Record<string, ModuleResult>;
+  issues: Issue[];
+  pages: PageMeta[];
+  downloads?: DownloadFinding[];
+}

--- a/backend/modules/csv-txt/README.md
+++ b/backend/modules/csv-txt/README.md
@@ -1,0 +1,3 @@
+# csv-txt
+
+Checks CSV and text files (placeholder).

--- a/backend/modules/csv-txt/index.ts
+++ b/backend/modules/csv-txt/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'csv-txt',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'csv-txt', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/modules/dom-aria/README.md
+++ b/backend/modules/dom-aria/README.md
@@ -1,0 +1,3 @@
+# dom-aria
+
+Checks DOM and ARIA issues using axe-core (placeholder).

--- a/backend/modules/dom-aria/index.ts
+++ b/backend/modules/dom-aria/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'dom-aria',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'dom-aria', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/modules/downloads/README.md
+++ b/backend/modules/downloads/README.md
@@ -1,0 +1,3 @@
+# downloads
+
+Detects downloadable files (placeholder).

--- a/backend/modules/downloads/index.ts
+++ b/backend/modules/downloads/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'downloads',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'downloads', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/modules/forms/README.md
+++ b/backend/modules/forms/README.md
@@ -1,0 +1,3 @@
+# forms
+
+Form heuristics (placeholder).

--- a/backend/modules/forms/index.ts
+++ b/backend/modules/forms/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'forms',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'forms', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/modules/office/README.md
+++ b/backend/modules/office/README.md
@@ -1,0 +1,3 @@
+# office
+
+Checks Office documents (placeholder).

--- a/backend/modules/office/index.ts
+++ b/backend/modules/office/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'office',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'office', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/modules/pdf/README.md
+++ b/backend/modules/pdf/README.md
@@ -1,0 +1,3 @@
+# pdf
+
+Checks PDF documents (placeholder).

--- a/backend/modules/pdf/index.ts
+++ b/backend/modules/pdf/index.ts
@@ -1,0 +1,11 @@
+import { Module } from '../../core/types.js';
+
+const mod: Module = {
+  slug: 'pdf',
+  version: '0.1.0',
+  async run(ctx) {
+    return { module: 'pdf', version: '0.1.0', findings: [] };
+  }
+};
+
+export default mod;

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,10 +3,11 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "crawl-scan": "tsx scripts/crawl-scan.ts",
+    "crawl": "tsx scripts/crawl-scan.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "render-reports": "tsx scripts/build-reports.ts",
+    "build:reports": "tsx scripts/build-reports.ts",
+    "scan:engine": "node --enable-source-maps dist/core/engine.js --url $URL --profile $PROFILE",
     "test": "tsx --test tests/**/*.test.ts"
   },
   "dependencies": {

--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -271,9 +271,18 @@ function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profil
 
 export async function main() {
   const outDir = process.env.OUTPUT_DIR || path.join(process.cwd(), "out");
-  const summary: ScanSummary = JSON.parse(await fs.readFile(path.join(outDir, "scan.json"), "utf-8"));
-  const issues: any[] = JSON.parse(await fs.readFile(path.join(outDir, "issues.json"), "utf-8"));
-  let downloadsReport: any[] = []; try { downloadsReport = JSON.parse(await fs.readFile(path.join(outDir, "downloads_report.json"), "utf-8")); } catch {}
+  const results = JSON.parse(await fs.readFile(path.join(outDir, "results.json"), "utf-8"));
+  const summary: ScanSummary = {
+    startUrl: results.meta?.target || '',
+    date: results.meta?.finishedAt || '',
+    pagesCrawled: results.pages?.length || 0,
+    downloadsFound: results.downloads?.length || 0,
+    score: results.score || { overall: 0, bySeverity: { critical: 0, serious: 0, moderate: 0, minor: 0 } },
+    totals: { violations: results.issues?.length || 0, incomplete: 0 },
+    jurisdiction: results.meta?.jurisdiction
+  };
+  const issues: any[] = results.issues || [];
+  let downloadsReport: any[] = results.downloads || [];
   let dynamicInteractions: any[] = []; try { dynamicInteractions = JSON.parse(await fs.readFile(path.join(outDir, "dynamic_interactions.json"), "utf-8")); } catch {}
 
   // Profil laden

--- a/backend/tests/config.test.ts
+++ b/backend/tests/config.test.ts
@@ -1,0 +1,15 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { loadConfig } from '../core/config.js';
+
+test('loadConfig merges profile modules', async () => {
+  const cfg = await loadConfig(['--profile', 'fast']);
+  assert.equal(cfg.profile, 'fast');
+  assert.equal(cfg.modules['dom-aria'], true);
+});
+
+test('modules override via cli', async () => {
+  const cfg = await loadConfig(['--modules', 'forms']);
+  assert.equal(Object.keys(cfg.modules).length, 1);
+  assert.ok(cfg.modules['forms']);
+});

--- a/backend/tests/ombuds.test.ts
+++ b/backend/tests/ombuds.test.ts
@@ -33,18 +33,15 @@ test('report build produces enforcement block and hint', async (t) => {
   const outDir = path.join(tmp, 'out');
   await fs.mkdir(outDir, { recursive: true });
   const now = new Date().toISOString();
-  const summary = {
-    startUrl: 'https://example.org',
-    date: now,
-    pagesCrawled: 0,
-    downloadsFound: 0,
+  const results = {
+    meta: { startedAt: now, finishedAt: now, target: 'https://example.org', profile: 'fast', jurisdiction: 'DE-TH' },
     score: { overall: 100, bySeverity: { critical:0, serious:0, moderate:0, minor:0 } },
-    totals: { violations:0, incomplete:0 },
-    jurisdiction: 'DE-TH'
+    modules: {},
+    issues: [],
+    pages: [],
+    downloads: []
   };
-  await fs.writeFile(path.join(outDir, 'scan.json'), JSON.stringify(summary));
-  await fs.writeFile(path.join(outDir, 'issues.json'), '[]');
-  await fs.writeFile(path.join(outDir, 'downloads_report.json'), '[]');
+  await fs.writeFile(path.join(outDir, 'results.json'), JSON.stringify(results));
   await fs.writeFile(path.join(outDir, 'dynamic_interactions.json'), '[]');
 
   const cfgDir = path.join(tmp, 'config');

--- a/backend/tests/registry.test.ts
+++ b/backend/tests/registry.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { loadConfig } from '../core/config.js';
+import { getModules } from '../core/registry.js';
+
+test('getModules loads modules from profile', async () => {
+  const cfg = await loadConfig(['--profile', 'fast']);
+  const mods = await getModules([], cfg.profile, cfg);
+  const slugs = mods.map(m => m.slug);
+  assert.ok(slugs.includes('dom-aria'));
+  assert.ok(slugs.includes('forms'));
+});
+
+test('getModules wildcard', async () => {
+  const cfg = await loadConfig();
+  const mods = await getModules(['*'], cfg.profile, cfg);
+  assert.ok(mods.length >= 6);
+});


### PR DESCRIPTION
## Summary
- add core types, config loader, module registry, and engine producing results.json
- introduce six placeholder modules and default profile config
- update reporting script and npm scripts

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a57bb7d3b0832c8792db3686001b7c