### PR TITLE
fix(ci): switch workflow to modular engine (crawl → engine → reports)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,61 @@
+name: scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Start URL to scan"
+        required: true
+        type: string
+      profile:
+        description: "Scan profile (fast|full)"
+        required: false
+        default: "fast"
+        type: choice
+        options: [fast, full]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install deps
+        working-directory: backend
+        run: npm ci
+
+      - name: Install Playwright (browsers + deps)
+        working-directory: backend
+        run: npx playwright install --with-deps
+
+      - name: Build (TypeScript → dist)
+        working-directory: backend
+        run: npm run build
+
+      - name: Crawl
+        working-directory: backend
+        run: npm run crawl -- --url "${{ inputs.url }}" --max-pages 50 --max-depth 3
+
+      - name: Run modular engine
+        working-directory: backend
+        run: npm run scan:engine -- --url "${{ inputs.url }}" --profile "${{ inputs.profile }}"
+
+      - name: Build reports (HTML/PDF)
+        working-directory: backend
+        run: npm run build:reports
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: accesschecker-out
+          path: |
+            backend/out/**

--- a/backend/scripts/crawl-scan.ts
+++ b/backend/scripts/crawl-scan.ts
@@ -1,3 +1,6 @@
+console.warn("[DEPRECATED] scripts/crawl-scan.ts is obsolete. Use: npm run crawl && npm run scan:engine && npm run build:reports");
+process.exit(2);
+
 /**
  * AccessChecker – erweiterter Site-Crawler + axe-core Scan
  * Abdeckung:


### PR DESCRIPTION
## Summary
- replace crawl-scan with modular pipeline: crawl → engine → reports
- build backend before running scan:engine
- accept URL and profile inputs, limit crawl, and upload out/** artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5c901c378832c9e7dd51ea26d1adb