### PR TITLE
fix(ci): run modular engine directly (remove legacy crawl step)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -41,10 +41,6 @@ jobs:
         working-directory: backend
         run: npm run build
 
-      - name: Crawl
-        working-directory: backend
-        run: npm run crawl -- --url "${{ inputs.url }}" --max-pages 50 --max-depth 3
-
       - name: Run modular engine
         working-directory: backend
         run: npm run scan:engine -- --url "${{ inputs.url }}" --profile "${{ inputs.profile }}"


### PR DESCRIPTION
## Summary
- run the new modular engine directly in the scan workflow
- remove legacy crawl step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6065b9d88832c85e379826b3b57da