### PR TITLE
feat: support dist modules

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,5 +9,5 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["src", "scripts", "scanners", "config", "reports", "types"]
+  "include": ["src", "scripts", "scanners", "config", "reports", "types", "core", "modules"]
 }


### PR DESCRIPTION
## Summary
- build includes `core` and `modules`
- registry chooses compiled modules when available and falls back to source

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6b78a6b18832c9364e3a6ce2cdc1a