### PR TITLE
feat(forms): deep form checks (labels, required, errors, groups, autocomplete) + report details table fill

### DIFF
--- a/backend/config/rules_mapping.json
+++ b/backend/config/rules_mapping.json
@@ -8,5 +8,11 @@
   "html-has-lang": { "wcag": ["3.1.1"], "bitv": ["3.1.1"], "severity": "serious" },
   "duplicate-id": { "wcag": ["4.1.1"], "bitv": ["4.1.1"], "severity": "critical" },
   "aria-allowed-attr": { "wcag": ["4.1.2"], "bitv": ["4.1.2"], "severity": "moderate" },
-  "aria-allowed-role": { "wcag": ["4.1.2"], "bitv": ["4.1.2"], "severity": "moderate" }
+  "aria-allowed-role": { "wcag": ["4.1.2"], "bitv": ["4.1.2"], "severity": "moderate" },
+  "forms:missing-label": { "wcag": ["1.3.1", "4.1.2"], "bitv": ["1.3.1", "4.1.2"], "severity": "serious" },
+  "forms:multiple-labels": { "wcag": ["3.3.2", "4.1.2"], "bitv": ["3.3.2", "4.1.2"], "severity": "moderate" },
+  "forms:error-not-associated": { "wcag": ["3.3.1", "3.3.3"], "bitv": ["3.3.1", "3.3.3"], "severity": "serious" },
+  "forms:required-not-indicated": { "wcag": ["3.3.2"], "bitv": ["3.3.2"], "severity": "moderate" },
+  "forms:missing-fieldset-legend": { "wcag": ["1.3.1"], "bitv": ["1.3.1"], "severity": "moderate" },
+  "forms:autocomplete-missing-or-wrong": { "wcag": ["1.3.5"], "bitv": ["1.3.5"], "severity": "minor" }
 }

--- a/backend/modules/forms/index.ts
+++ b/backend/modules/forms/index.ts
@@ -1,10 +1,71 @@
-import { Module } from '../../core/types.js';
+import { Module, Severity, Finding, NormRefs } from '../../core/types.js';
+import rulesMapping from '../../config/rules_mapping.json' assert { type: 'json' };
+import { collectFormControls } from '../../src/a11y/forms.js';
+
+const map: Record<string, { wcag?: string[]; bitv?: string[]; severity?: Severity }> = rulesMapping as any;
 
 const mod: Module = {
   slug: 'forms',
-  version: '0.1.0',
+  version: '0.2.0',
   async run(ctx) {
-    return { module: 'forms', version: '0.1.0', findings: [] };
+    const { fields, groups } = await ctx.page.evaluate(collectFormControls);
+    const overviewPath = await ctx.saveArtifact('forms_overview.json', fields);
+
+    const findings: Finding[] = [];
+    const stats: Record<string, number> = {};
+
+    function addFinding(id: string, summary: string, details: string, selectors: string[]) {
+      const m = map[id] || {};
+      const norms: NormRefs = {};
+      if (m.wcag) norms.wcag = m.wcag;
+      if (m.bitv) norms.bitv = m.bitv;
+      const severity: Severity = (m.severity || 'moderate') as Severity;
+      findings.push({ id, module: 'forms', severity, summary, details, selectors, pageUrl: ctx.url, ...(Object.keys(norms).length ? { norms } : {}) });
+      stats[id] = (stats[id] || 0) + 1;
+    }
+
+    for (const f of fields) {
+      if (!f.labels.length) {
+        addFinding('forms:missing-label', 'Form field has no label', 'Input/select/textarea element lacks accessible name', [f.selector]);
+      } else if (f.labels.length > 1) {
+        addFinding('forms:multiple-labels', 'Form field has multiple labels', 'Field is associated with multiple visible labels', [f.selector]);
+      }
+
+      if (f.validation && !f.hasErrorBinding) {
+        addFinding('forms:error-not-associated', 'Validation error not associated', 'Field has validation attributes but no associated error message via aria-describedby', [f.selector]);
+      }
+
+      if (f.required) {
+        const txt = (f.labels.join(' ') || '').toLowerCase();
+        const visible = txt.includes('*') || /required|erforderlich|pflichtfeld|mandatory|obligatory/.test(txt);
+        if (!visible && !f.ariaRequired) {
+          addFinding('forms:required-not-indicated', 'Required field not indicated', 'Field marked as required but not indicated in label or aria-required', [f.selector]);
+        }
+      }
+
+      const labelLower = (f.labels.join(' ') + ' ' + f.name).toLowerCase();
+      let expected: { type?: string; autocomplete?: string } | null = null;
+      if (/e-?mail/.test(labelLower)) expected = { type: 'email', autocomplete: 'email' };
+      else if (/phone|tel|telefon/.test(labelLower)) expected = { type: 'tel', autocomplete: 'tel' };
+      else if (/postleitzahl|\bplz\b|postal|zip/.test(labelLower)) expected = { autocomplete: 'postal-code' };
+      if (expected) {
+        const typeWrong = expected.type && expected.type !== f.type;
+        const ac = (f.autocomplete || '').toLowerCase();
+        const acWrong = expected.autocomplete && ac !== expected.autocomplete;
+        if (typeWrong || acWrong || !ac) {
+          addFinding('forms:autocomplete-missing-or-wrong', 'Autocomplete/type missing or wrong', 'Field could benefit from appropriate type or autocomplete', [f.selector]);
+        }
+      }
+    }
+
+    for (const name in groups) {
+      const g = groups[name];
+      if (g.selectors.length > 1 && !g.hasFieldsetLegend) {
+        addFinding('forms:missing-fieldset-legend', 'Form controls missing fieldset/legend', 'Group of radio buttons or checkboxes lacks fieldset/legend', g.selectors.slice(0, 1));
+      }
+    }
+
+    return { module: 'forms', version: '0.2.0', findings, stats, artifacts: { overview: overviewPath } };
   }
 };
 

--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -66,10 +66,10 @@ function vereinbarkeitsStatus(violations: number, score: number) {
 function deriveTopFindings(issues: any[], limit = 8) {
   const map = new Map<string, { id: string; text: string; wcag: string[]; count: number }>();
   for (const v of issues) {
-    const key = v.ruleId || v.description || "unbekannt";
-    const entry = map.get(key) || { id: v.ruleId || key, text: v.description || key, wcag: v.wcag || [], count: 0 };
+    const key = v.id || v.summary || 'unbekannt';
+    const entry = map.get(key) || { id: v.id || key, text: v.summary || key, wcag: v.norms?.wcag || [], count: 0 };
     entry.count += 1;
-    if (Array.isArray(v.wcag) && v.wcag.length) entry.wcag = v.wcag;
+    if (Array.isArray(v.norms?.wcag) && v.norms.wcag.length) entry.wcag = v.norms.wcag;
     map.set(key, entry);
   }
   return Array.from(map.values()).sort((a, b) => b.count - a.count).slice(0, limit);
@@ -77,11 +77,11 @@ function deriveTopFindings(issues: any[], limit = 8) {
 
 function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport: any[], dynamic: any[]) {
   const rows = issues.slice(0, 300).map((v: any) => {
-    const targets = (v.examples || []).slice(0, 3).map((n: any) => `<code>${escapeHtml(n.selector)}</code><br/><small>${escapeHtml(n.pageUrl)}</small><br/><small>${escapeHtml(n.context)}</small>`).join("<br/>");
-    const wcag = (v.wcag || []).join(", "); const bitv = (v.bitv || []).join(", "); const en = (v.en301549 || []).join(", ");
+    const targets = (v.selectors || []).slice(0, 3).map((sel: string) => `<code>${escapeHtml(sel)}</code><br/><small>${escapeHtml(v.pageUrl || '')}</small>`).join("<br/>");
+    const wcag = (v.norms?.wcag || []).join(", "); const bitv = (v.norms?.bitv || []).join(", "); const en = (v.norms?.en301549 || []).join(", ");
     return `<tr>
-      <td><b>${escapeHtml(v.ruleId||"")}</b><br/><small>${escapeHtml(v.description||"")}</small></td>
-      <td>${escapeHtml(v.impact||"n/a")}</td>
+      <td><b>${escapeHtml(v.id||"")}</b><br/><small>${escapeHtml(v.summary||"")}</small></td>
+      <td>${escapeHtml(v.severity||"n/a")}</td>
       <td><small>WCAG: ${escapeHtml(wcag)}<br/>BITV: ${escapeHtml(bitv)}<br/>EN: ${escapeHtml(en)}</small></td>
       <td>${targets}</td>
     </tr>`;

--- a/backend/src/a11y/forms.ts
+++ b/backend/src/a11y/forms.ts
@@ -1,0 +1,39 @@
+import { getNameInfo } from './name.js';
+
+export function collectFormControls() {
+  const fields: any[] = [];
+  const groups: Record<string, { selectors: string[]; hasFieldsetLegend: boolean; type: string }> = {};
+  const all = Array.from(document.querySelectorAll('input, select, textarea')) as HTMLElement[];
+  for (const el of all) {
+    const tag = el.tagName.toLowerCase();
+    const type = (el as HTMLInputElement).type || tag;
+    if (type === 'hidden' || (el as HTMLInputElement).disabled) continue;
+    const { texts, sources } = getNameInfo(el as HTMLElement);
+    const required = el.hasAttribute('required') || el.getAttribute('aria-required') === 'true';
+    const validation = required || el.getAttribute('aria-invalid') === 'true' || el.hasAttribute('pattern') || el.hasAttribute('min') || el.hasAttribute('max');
+    const describedbyIds = (el.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+    let hasErrorBinding = false;
+    for (const id of describedbyIds) {
+      const d = document.getElementById(id);
+      if (d && (['alert','status'].includes(d.getAttribute('role') || '') || ((d.getAttribute('aria-live') || '').toLowerCase() !== '' && (d.getAttribute('aria-live') || '').toLowerCase() !== 'off'))) {
+        hasErrorBinding = true;
+      }
+    }
+    const idSel = el.getAttribute('id') ? `#${CSS.escape(el.getAttribute('id')!)}` : '';
+    const nameSel = el.getAttribute('name') ? `[name="${CSS.escape(el.getAttribute('name')!)}"]` : '';
+    const selector = idSel || `${tag}${nameSel}`;
+    const autocomplete = el.getAttribute('autocomplete') || '';
+    fields.push({ selector, labels: texts, labelSources: sources, required, ariaRequired: el.getAttribute('aria-required') === 'true', validation, hasErrorBinding, autocomplete, type, name: el.getAttribute('name') || '' });
+    if ((type === 'radio' || type === 'checkbox') && el.getAttribute('name')) {
+      const g = groups[el.getAttribute('name')!] || { selectors: [], hasFieldsetLegend: false, type };
+      g.selectors.push(selector);
+      const fs = el.closest('fieldset');
+      if (fs) {
+        const lg = fs.querySelector('legend');
+        if (lg && lg.textContent && lg.textContent.trim()) g.hasFieldsetLegend = true;
+      }
+      groups[el.getAttribute('name')!] = g;
+    }
+  }
+  return { fields, groups };
+}

--- a/backend/src/a11y/name.ts
+++ b/backend/src/a11y/name.ts
@@ -1,0 +1,38 @@
+export function getNameInfo(el: HTMLElement) {
+  const texts: string[] = [];
+  const sources: string[] = [];
+  const id = el.getAttribute('id');
+  if (id) {
+    const lbl = document.querySelector(`label[for="${CSS.escape(id)}"]`);
+    if (lbl) {
+      texts.push(lbl.textContent?.trim() || '');
+      sources.push('label[for]');
+    }
+  }
+  let parent: HTMLElement | null = el.parentElement;
+  while (parent) {
+    if (parent.tagName.toLowerCase() === 'label') {
+      texts.push(parent.textContent?.trim() || '');
+      sources.push('label-wrapper');
+      break;
+    }
+    parent = parent.parentElement;
+  }
+  const ariaLabelledby = el.getAttribute('aria-labelledby');
+  if (ariaLabelledby) {
+    for (const ref of ariaLabelledby.split(/\s+/)) {
+      const e = document.getElementById(ref);
+      if (e) {
+        texts.push(e.textContent?.trim() || '');
+        sources.push('aria-labelledby');
+      }
+    }
+  }
+  const ariaLabel = el.getAttribute('aria-label');
+  if (ariaLabel) {
+    texts.push(ariaLabel.trim());
+    sources.push('aria-label');
+  }
+  const uniqTexts = Array.from(new Set(texts.filter(Boolean)));
+  return { texts: uniqTexts, sources };
+}

--- a/backend/tests/forms.test.ts
+++ b/backend/tests/forms.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { main as engineMain } from '../core/engine.js';
+
+const TEST_URL = 'https://www.w3.org/WAI/demos/bad/';
+
+test('forms module reports findings and overview artifact', async (t) => {
+  const orig = process.argv;
+  process.argv = process.argv.slice(0,2).concat(['--url', TEST_URL, '--profile', 'fast']);
+  let results: any;
+  try {
+    results = await engineMain();
+  } catch (e) {
+    t.skip(`Engine run failed: ${e}`);
+    return;
+  } finally {
+    process.argv = orig;
+  }
+  assert.ok(results.modules['forms'].findings.length > 0, 'expected forms findings');
+  const overviewPath = path.join(process.cwd(), 'out', 'forms_overview.json');
+  try {
+    await fs.access(overviewPath);
+  } catch {
+    assert.fail('forms_overview.json missing');
+  }
+  assert.ok(results.issues.some((f: any) => f.id.startsWith('forms:')), 'issues should include forms findings');
+  assert.ok(results.issues.some((f: any) => f.id.startsWith('axe:')), 'issues should include axe findings');
+});


### PR DESCRIPTION
## Summary
- implement dedicated form evaluation module with label, error, required, grouping and autocomplete checks
- expose form field overview artifact and extend rules mapping for form rules
- include form findings in internal report table and add test coverage

## Testing
- `npm test` *(fails: Engine run failed: Error: page.goto: net::ERR_CERT_AUTHORITY_INVALID at https://www.w3.org/WAI/demos/bad/)*
- `npm run build`
- `node dist/core/engine.js --url https://www.w3.org/WAI/demos/bad/ --profile fast` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_68a80fe8f65c832ca9195b17b2a58f1c