### PR TITLE
feat(forms): add deep form checks

### DIFF
--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -146,7 +146,8 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
   if (summary.totals.violations === 0 && !(profile.manualFindings && profile.manualFindings.length)) {
     status = { ...status, code: "unknown" };
   }
-  const top = deriveTopFindings(issues, 8);
+  const formIssues = issues.filter((v: any) => (v.id || '').startsWith('forms:'));
+  const top = formIssues.length ? deriveTopFindings(formIssues, 3) : deriveTopFindings(issues, 8);
   const today = new Date().toISOString().slice(0,10);
 
   const plainMap: Record<string, string> = {
@@ -154,7 +155,13 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
     "image-alt": "Bilder ohne Alternativtext",
     "color-contrast": "Texte haben zu wenig Farbkontrast",
     "html-has-lang": "Seite nennt keine Sprache",
-    "document-title": "Seite hat keinen Titel"
+    "document-title": "Seite hat keinen Titel",
+    "forms:missing-label": "Formularfeld ohne Beschriftung",
+    "forms:multiple-labels": "Formularfeld mit mehreren Beschriftungen",
+    "forms:error-not-associated": "Fehlermeldung nicht mit Feld verknüpft",
+    "forms:required-not-indicated": "Pflichtfeld nicht gekennzeichnet",
+    "forms:missing-fieldset-legend": "Gruppe ohne fieldset/legend",
+    "forms:autocomplete-missing-or-wrong": "Autocomplete oder Typ fehlt/falsch"
   };
 
   const topList = top.length
@@ -226,14 +233,21 @@ function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profil
   if (summary.totals.violations === 0 && !(profile.manualFindings && profile.manualFindings.length)) {
     status = { ...status, code: "unknown" };
   }
-  const top = deriveTopFindings(issues, 8);
+  const formIssues = issues.filter((v: any) => (v.id || '').startsWith('forms:'));
+  const top = formIssues.length ? deriveTopFindings(formIssues, 3) : deriveTopFindings(issues, 8);
   const preparedOn = new Date().toISOString().slice(0,10);
   const plainMap: Record<string, string> = {
     "link-name": "Links haben kein erkennbares Ziel",
     "image-alt": "Bilder ohne Alternativtext",
     "color-contrast": "Texte haben zu wenig Farbkontrast",
     "html-has-lang": "Seite nennt keine Sprache",
-    "document-title": "Seite hat keinen Titel"
+    "document-title": "Seite hat keinen Titel",
+    "forms:missing-label": "Formularfeld ohne Beschriftung",
+    "forms:multiple-labels": "Formularfeld mit mehreren Beschriftungen",
+    "forms:error-not-associated": "Fehlermeldung nicht mit Feld verknüpft",
+    "forms:required-not-indicated": "Pflichtfeld nicht gekennzeichnet",
+    "forms:missing-fieldset-legend": "Gruppe ohne fieldset/legend",
+    "forms:autocomplete-missing-or-wrong": "Autocomplete oder Typ fehlt/falsch"
   };
 
   return {

--- a/backend/tests/forms.test.ts
+++ b/backend/tests/forms.test.ts
@@ -2,7 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { chromium } from 'playwright';
 import { main as engineMain } from '../core/engine.js';
+import { main as buildReports } from '../scripts/build-reports.js';
 
 const TEST_URL = 'https://www.w3.org/WAI/demos/bad/';
 
@@ -19,12 +21,19 @@ test('forms module reports findings and overview artifact', async (t) => {
     process.argv = orig;
   }
   assert.ok(results.modules['forms'].findings.length > 0, 'expected forms findings');
+
   const overviewPath = path.join(process.cwd(), 'out', 'forms_overview.json');
-  try {
-    await fs.access(overviewPath);
-  } catch {
-    assert.fail('forms_overview.json missing');
-  }
-  assert.ok(results.issues.some((f: any) => f.id.startsWith('forms:')), 'issues should include forms findings');
+  const overview = JSON.parse(await fs.readFile(overviewPath, 'utf-8'));
+  assert.ok(Array.isArray(overview) && overview.length > 0, 'overview should list fields');
+
+  const issuesFile = JSON.parse(await fs.readFile(path.join(process.cwd(), 'out', 'issues.json'), 'utf-8'));
+  assert.ok(issuesFile.some((f: any) => f.id.startsWith('forms:')), 'issues.json should include forms findings');
   assert.ok(results.issues.some((f: any) => f.id.startsWith('axe:')), 'issues should include axe findings');
+
+  const fakePage = { setViewportSize() {}, setContent() {}, pdf: async () => {} } as any;
+  const fakeBrowser = { newPage: async () => fakePage, close: async () => {} } as any;
+  t.mock.method(chromium, 'launch', async () => fakeBrowser);
+  await buildReports();
+  const report = await fs.readFile(path.join(process.cwd(), 'out', 'report_internal.html'), 'utf-8');
+  assert.ok(/forms:/.test(report), 'internal report should mention forms findings');
 });


### PR DESCRIPTION
## Summary
- implement label, validation, required, grouping, and autocomplete checks for form fields
- integrate forms findings into reports and public statement
- extend test to verify form overview and report output

## Testing
- `npm test` *(fails: page.goto net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_68a824b46e9c832ca25cd643f46e04ea