### PR TITLE
feat(semantics-landmarks): add landmark coverage & quality checks; integrate into reports and public statement

### DIFF
--- a/backend/config/scan.defaults.json
+++ b/backend/config/scan.defaults.json
@@ -4,10 +4,11 @@
     "dom-aria": true,
     "keyboard-focus": true,
     "forms": true,
-    "downloads": true
+    "downloads": true,
+    "semantics-landmarks": true
   },
   "profiles": {
-    "fast": ["dom-aria","keyboard-focus","forms","downloads"],
+    "fast": ["dom-aria","keyboard-focus","forms","downloads","semantics-landmarks"],
     "full": ["*"]
   },
   "maxPages": 100,

--- a/backend/modules/semantics-landmarks/README.md
+++ b/backend/modules/semantics-landmarks/README.md
@@ -1,0 +1,3 @@
+# semantics-landmarks
+
+Analysiert die Landmark-Struktur einer Seite und ermittelt Abdeckungsquote sowie Qualitätsprobleme wie fehlendes `<main>` oder mehrfach vorhandene Banner/Footer.

--- a/backend/modules/semantics-landmarks/index.ts
+++ b/backend/modules/semantics-landmarks/index.ts
@@ -1,0 +1,189 @@
+import { Module, Finding } from '../../core/types.js';
+
+interface LandmarkInfo {
+  selector: string;
+  topLevel: boolean;
+}
+
+const mod: Module = {
+  slug: 'semantics-landmarks',
+  version: '0.1.0',
+  async run(ctx) {
+    const data = await ctx.page.evaluate(() => {
+      function cssPath(el: Element): string {
+        if ((el as HTMLElement).id) return `#${(el as HTMLElement).id}`;
+        const parts: string[] = [];
+        let e: Element | null = el;
+        while (e && parts.length < 4) {
+          let part = e.tagName.toLowerCase();
+          let sibling = e.previousElementSibling;
+          let count = 1;
+          while (sibling) {
+            if (sibling.tagName === e.tagName) count++;
+            sibling = sibling.previousElementSibling as Element | null;
+          }
+          part += `:nth-of-type(${count})`;
+          parts.unshift(part);
+          e = e.parentElement;
+        }
+        return parts.join('>');
+      }
+      function isVisible(el: Element): boolean {
+        const style = window.getComputedStyle(el as HTMLElement);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+
+      const res: any = {
+        counts: { main: 0, banner: 0, navigation: 0, complementary: 0, contentinfo: 0, search: 0, region: 0 },
+        main: [] as LandmarkInfo[],
+        banner: [] as LandmarkInfo[],
+        navigation: [] as LandmarkInfo[],
+        complementary: [] as LandmarkInfo[],
+        contentinfo: [] as LandmarkInfo[],
+        search: [] as LandmarkInfo[],
+        region: [] as LandmarkInfo[],
+        coverage: 0,
+      };
+
+      const cand = Array.from(document.querySelectorAll('main, header, nav, aside, footer, form[role="search"], [role]'));
+      const landmarks: Element[] = [];
+      for (const el of cand) {
+        let type = (el.getAttribute('role') || '').toLowerCase();
+        const tag = el.tagName.toLowerCase();
+        if (!type) {
+          if (tag === 'header') type = 'banner';
+          else if (tag === 'nav') type = 'navigation';
+          else if (tag === 'aside') type = 'complementary';
+          else if (tag === 'footer') type = 'contentinfo';
+          else if (tag === 'main') type = 'main';
+        }
+        if (!type) continue;
+        if (!(res.counts as any).hasOwnProperty(type)) {
+          type = 'region';
+        }
+        res.counts[type] = (res.counts[type] || 0) + 1;
+        const info = { selector: cssPath(el), topLevel: el.parentElement === document.body };
+        (res as any)[type].push(info);
+        landmarks.push(el);
+      }
+
+      const all = Array.from(document.body.querySelectorAll('*'));
+      let total = 0, covered = 0;
+      for (const el of all) {
+        if (!isVisible(el)) continue;
+        total++;
+        let cur: Element | null = el;
+        let ok = false;
+        while (cur) {
+          if (landmarks.includes(cur)) { ok = true; break; }
+          cur = cur.parentElement;
+        }
+        if (ok) covered++;
+      }
+      res.coverage = total ? Math.round((covered / total) * 100) : 0;
+
+      return res;
+    });
+
+    const findings: Finding[] = [];
+    const norms = { wcag: ['1.3.1'] };
+
+    if (data.counts.main === 0) {
+      findings.push({
+        id: 'landmarks:missing-main',
+        module: 'semantics-landmarks',
+        severity: 'moderate',
+        summary: 'No main landmark present',
+        details: 'Add a single <main> element around the primary content. See axe:landmark-one-main.',
+        pageUrl: ctx.url,
+        norms,
+      });
+    } else if (data.counts.main > 1) {
+      findings.push({
+        id: 'landmarks:duplicates-main',
+        module: 'semantics-landmarks',
+        severity: 'minor',
+        summary: 'Multiple main landmarks',
+        details: 'Use only one <main> element per page; remove role=main from other containers.',
+        selectors: data.main.slice(0, 2).map((m: LandmarkInfo) => m.selector),
+        pageUrl: ctx.url,
+        norms,
+      });
+    }
+
+    if (data.counts.banner > 1) {
+      findings.push({
+        id: 'landmarks:duplicates-banner',
+        module: 'semantics-landmarks',
+        severity: 'minor',
+        summary: 'Multiple banner landmarks',
+        details: 'Only one banner (header) landmark should be present.',
+        selectors: data.banner.slice(0, 2).map((m: LandmarkInfo) => m.selector),
+        pageUrl: ctx.url,
+        norms,
+      });
+    }
+    if (data.counts.contentinfo > 1) {
+      findings.push({
+        id: 'landmarks:duplicates-contentinfo',
+        module: 'semantics-landmarks',
+        severity: 'minor',
+        summary: 'Multiple contentinfo landmarks',
+        details: 'Only one contentinfo (footer) landmark should be present.',
+        selectors: data.contentinfo.slice(0, 2).map((m: LandmarkInfo) => m.selector),
+        pageUrl: ctx.url,
+        norms,
+      });
+    }
+
+    const nestedBanner = data.banner.filter((b: LandmarkInfo) => !b.topLevel).map((b: LandmarkInfo) => b.selector);
+    if (nestedBanner.length) {
+      findings.push({
+        id: 'landmarks:nesting-banner',
+        module: 'semantics-landmarks',
+        severity: 'minor',
+        summary: 'Banner landmark is nested',
+        details: 'Banner landmarks should be top-level children of <body>.',
+        selectors: nestedBanner.slice(0, 5),
+        pageUrl: ctx.url,
+        norms,
+      });
+    }
+    const nestedContentinfo = data.contentinfo.filter((b: LandmarkInfo) => !b.topLevel).map((b: LandmarkInfo) => b.selector);
+    if (nestedContentinfo.length) {
+      findings.push({
+      id: 'landmarks:nesting-contentinfo',
+      module: 'semantics-landmarks',
+      severity: 'minor',
+      summary: 'Contentinfo landmark is nested',
+      details: 'Contentinfo (footer) landmarks should be top-level children of <body>.',
+      selectors: nestedContentinfo.slice(0,5),
+      pageUrl: ctx.url,
+      norms,
+      });
+    }
+
+    if (data.coverage < 80) {
+      findings.push({
+        id: 'landmarks:coverage-low',
+        module: 'semantics-landmarks',
+        severity: 'minor',
+        summary: `Landmark coverage ${data.coverage}%`,
+        details: 'Ensure that most visible content is within landmark regions.',
+        pageUrl: ctx.url,
+        norms,
+      });
+    }
+
+    return {
+      module: 'semantics-landmarks',
+      version: '0.1.0',
+      findings,
+      metrics: { coverage: data.coverage, counts: data.counts },
+    } as any;
+  }
+};
+
+export default mod;

--- a/backend/tests/semantics-landmarks.test.ts
+++ b/backend/tests/semantics-landmarks.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { chromium } from 'playwright';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import mod from '../modules/semantics-landmarks/index.ts';
+import { main as engineMain } from '../core/engine.js';
+import { main as buildReports } from '../scripts/build-reports.js';
+
+async function runSnippet(html: string) {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.setContent(html);
+  const ctx: any = { page, url: 'http://example.com', crawlGraph: [], config: {}, log() {}, saveArtifact: async () => '' };
+  const res = await mod.run(ctx);
+  await browser.close();
+  return res;
+}
+
+test('missing main → missing-main finding', async () => {
+  const res = await runSnippet('<div>no main</div>');
+  assert.ok(res.findings.some((f: any) => f.id === 'landmarks:missing-main'));
+});
+
+test('two banners → duplicates-banner', async () => {
+  const res = await runSnippet('<header role="banner"></header><header role="banner"></header><main></main>');
+  assert.ok(res.findings.some((f: any) => f.id === 'landmarks:duplicates-banner'));
+});
+
+test('banner within main → nesting-banner', async () => {
+  const res = await runSnippet('<main><header role="banner"></header></main>');
+  assert.ok(res.findings.some((f: any) => f.id === 'landmarks:nesting-banner'));
+});
+
+test('coverage 60% → coverage-low', async () => {
+  const res = await runSnippet('<header></header><main><p>inside</p></main><div></div><div></div>');
+  assert.ok(res.findings.some((f: any) => f.id === 'landmarks:coverage-low'));
+});
+
+test('e2e: BAD demo site yields landmark finding and appears in reports', async (t) => {
+  const TEST_URL = 'https://www.w3.org/WAI/demos/bad/';
+  const orig = process.argv;
+  process.argv = process.argv.slice(0,2).concat(['--url', TEST_URL, '--profile', 'fast']);
+  let results: any;
+  try {
+    results = await engineMain();
+  } catch (e) {
+    t.skip(`Engine run failed: ${e}`);
+    return;
+  } finally {
+    process.argv = orig;
+  }
+  const lm = results.modules['semantics-landmarks'];
+  assert.ok(lm && lm.findings.length > 0, 'expected landmark findings');
+  assert.ok(results.issues.some((f: any) => f.module === 'semantics-landmarks'), 'issues should include landmarks findings');
+  assert.ok(results.issues.some((f: any) => (f.id || '').startsWith('axe:')), 'axe findings should remain');
+  const issuesFile = JSON.parse(await fs.readFile(path.join(process.cwd(), 'out', 'issues.json'), 'utf-8'));
+  assert.ok(issuesFile.some((f: any) => f.module === 'semantics-landmarks'));
+
+  const fakePage = { setViewportSize() {}, setContent() {}, pdf: async () => {} } as any;
+  const fakeBrowser = { newPage: async () => fakePage, close: async () => {} } as any;
+  t.mock.method(chromium, 'launch', async () => fakeBrowser);
+  await buildReports();
+  const report = await fs.readFile(path.join(process.cwd(), 'out', 'report_internal.html'), 'utf-8');
+  assert.ok(/Landmark-Abdeckung/.test(report), 'internal report should mention landmark coverage');
+  const reportPub = await fs.readFile(path.join(process.cwd(), 'out', 'report_public.html'), 'utf-8');
+  assert.ok(/Landmark-Abdeckung/.test(reportPub), 'public report should mention landmark coverage');
+});


### PR DESCRIPTION
## Summary
- add `semantics-landmarks` module to analyse landmark structure, compute coverage and detect issues
- include landmark metrics and findings in reports and public statement
- cover landmarks in default `fast` profile and add dedicated tests

## Testing
- `npm test` *(fails: net::ERR_CERT_AUTHORITY_INVALID when running e2e tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a8506df844832c856738d9c58ba864