### PR TITLE
fix(types): extend Finding with optional metrics to support links/landmarks modules

### DIFF
--- a/backend/core/types.ts
+++ b/backend/core/types.ts
@@ -16,6 +16,7 @@ export interface Finding {
   selectors?: string[];
   pageUrl: string;
   norms?: NormRefs;
+  metrics?: Record<string, string | number>;
 }
 
 export interface Issue extends Finding {}

--- a/backend/modules/landmarks/index.ts
+++ b/backend/modules/landmarks/index.ts
@@ -1,14 +1,5 @@
 import { Module, Finding } from '../../core/types.js';
 
-export type LandmarkFinding = {
-  id: string;
-  severity: 'minor' | 'moderate' | 'serious';
-  summary: string;
-  details?: string;
-  selectors?: string[];
-  metrics?: Record<string, number | string>;
-};
-
 export type RemediationHint = {
   title: string;
   snippet: string;
@@ -101,7 +92,7 @@ const mod: Module = {
       metrics: { coveragePercent: data.coveragePercent, badge: coverageBadge(data.coveragePercent) },
       pageUrl: ctx.url,
       norms,
-    } as any);
+    });
 
     if (data.counts.main === 0) {
       findings.push({ id: 'landmarks:missing-main', module: 'landmarks', severity: 'moderate', summary: 'Fehlendes <main>-Element', details: '', pageUrl: ctx.url, norms });

--- a/backend/modules/links/index.ts
+++ b/backend/modules/links/index.ts
@@ -2,20 +2,6 @@ import { Module, Finding } from '../../core/types.js';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-export type LinkFinding = {
-  id:
-    | 'links:nondescriptive'
-    | 'links:raw-url'
-    | 'links:text-dup-different-target'
-    | 'links:target-dup-different-text'
-    | 'links:icon-only';
-  severity: 'minor' | 'moderate' | 'serious';
-  summary: string;
-  details?: string;
-  selectors?: string[];
-  metrics?: Record<string, number | string>;
-};
-
 export type LinksStats = {
   total: number;
   nondescriptive: number;


### PR DESCRIPTION
## Summary
- allow findings to expose optional metrics map
- rely on base `Finding` type in links and landmarks modules

## Testing
- `npm run build`
- `npm run scan:engine -- --url https://www.w3.org/WAI/demos/bad/ --profile fast` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_68aa017adb3c832c816536c67102186d