### PR TITLE
feat: add images analysis module

### DIFF
--- a/backend/config/scan.defaults.json
+++ b/backend/config/scan.defaults.json
@@ -7,7 +7,8 @@
     "downloads": true,
     "landmarks": true,
     "headings-outline": true,
-    "links": true
+    "links": true,
+    "images": true
   },
   "profiles": {
     "fast": [
@@ -17,7 +18,8 @@
       "downloads",
       "landmarks",
       "headings-outline",
-      "links"
+      "links",
+      "images"
     ],
     "full": [
       "*"

--- a/backend/modules/images/README.md
+++ b/backend/modules/images/README.md
@@ -1,0 +1,3 @@
+# Images Module
+
+Checks images for alt text and SVG titles.

--- a/backend/modules/images/index.ts
+++ b/backend/modules/images/index.ts
@@ -1,0 +1,276 @@
+import type { Module, Finding } from '../../core/types.js';
+
+function normalize(s: string | null): string {
+  return (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+const mod: Module = {
+  slug: 'images',
+  version: '0.1.0',
+  async run(ctx) {
+    const raw: any[] = await ctx.page.evaluate(() => {
+      function __name(e: any, _?: any) { return e; }
+      function cssPath(el: Element): string {
+        if ((el as HTMLElement).id) return `#${(el as HTMLElement).id}`;
+        const parts: string[] = [];
+        let e: Element | null = el;
+        while (e && parts.length < 4) {
+          let part = e.tagName.toLowerCase();
+          let sib = e.previousElementSibling;
+          let cnt = 1;
+          while (sib) {
+            if (sib.tagName === e.tagName) cnt++;
+            sib = sib.previousElementSibling;
+          }
+          part += `:nth-of-type(${cnt})`;
+          parts.unshift(part);
+          e = e.parentElement;
+        }
+        return parts.join('>');
+      }
+      function isVisible(el: Element): boolean {
+        const style = window.getComputedStyle(el as HTMLElement);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      const results: any[] = [];
+      for (const el of Array.from(document.querySelectorAll('img'))) {
+        if (!isVisible(el)) continue;
+        const link = el.closest('a,button');
+        results.push({
+          type: 'img',
+          alt: el.getAttribute('alt'),
+          src: el.getAttribute('src') || '',
+          role: el.getAttribute('role') || '',
+          ariaHidden: el.getAttribute('aria-hidden') === 'true',
+          selector: cssPath(el),
+          filename: (el.getAttribute('src') || '').split('/').pop() || '',
+          parentText: link ? (link.textContent || '').trim() : '',
+          naturalWidth: (el as HTMLImageElement).naturalWidth,
+          naturalHeight: (el as HTMLImageElement).naturalHeight,
+        });
+      }
+      for (const el of Array.from(document.querySelectorAll('svg'))) {
+        if (!isVisible(el)) continue;
+        const link = el.closest('a,button');
+        const labelledby = el.getAttribute('aria-labelledby');
+        let labelledbyText = '';
+        if (labelledby) {
+          for (const id of labelledby.split(/\s+/)) {
+            const ref = document.getElementById(id);
+            if (ref) labelledbyText += ' ' + (ref.textContent || '').trim();
+          }
+          labelledbyText = labelledbyText.trim();
+        }
+        results.push({
+          type: 'svg',
+          hasTitle: !!el.querySelector('title'),
+          hasDesc: !!el.querySelector('desc'),
+          ariaLabel: el.getAttribute('aria-label') || '',
+          labelledbyText,
+          role: el.getAttribute('role') || '',
+          ariaHidden: el.getAttribute('aria-hidden') === 'true',
+          selector: cssPath(el),
+          inLink: !!link,
+        });
+      }
+      for (const el of Array.from(document.querySelectorAll('*'))) {
+        const style = window.getComputedStyle(el as HTMLElement);
+        if (!isVisible(el) || !style.backgroundImage || style.backgroundImage === 'none') continue;
+        const m = style.backgroundImage.match(/url\((['\"]?)([^'\"]+)\1\)/);
+        if (m) {
+          results.push({ type: 'css', src: m[2], selector: cssPath(el) });
+        }
+      }
+      for (const el of Array.from(document.querySelectorAll('input[type="image"]'))) {
+        if (!isVisible(el)) continue;
+        results.push({
+          type: 'input-image',
+          alt: el.getAttribute('alt') || '',
+          src: el.getAttribute('src') || '',
+          selector: cssPath(el),
+        });
+      }
+      for (const el of Array.from(document.querySelectorAll('area'))) {
+        results.push({
+          type: 'area',
+          alt: el.getAttribute('alt') || '',
+          ariaLabel: el.getAttribute('aria-label') || '',
+          selector: cssPath(el),
+        });
+      }
+      return results;
+    });
+
+    const stats = { total: 0, withAlt: 0, missingAlt: 0, decorativeCount: 0, svgCount: 0 };
+    const findings: Finding[] = [];
+
+    const missingAltSelectors: string[] = [];
+    const redundantSelectors: string[] = [];
+    const decorativeSelectors: string[] = [];
+    const filenameSelectors: string[] = [];
+    const imageOfTextSelectors: string[] = [];
+    const svgMissingTitleSel: string[] = [];
+    const inputImageMissingSel: string[] = [];
+    const areaMissingAltSel: string[] = [];
+
+    for (const r of raw) {
+      if (r.type === 'img') {
+        stats.total++;
+        const alt = r.alt || '';
+        const hasAlt = alt.trim().length > 0;
+        if (hasAlt) stats.withAlt++; else stats.missingAlt++;
+        const isDecorative = ['presentation', 'none'].includes((r.role || '').toLowerCase()) || r.ariaHidden;
+        if (isDecorative) stats.decorativeCount++;
+        if (!hasAlt && !isDecorative) {
+          if (missingAltSelectors.length < 20) missingAltSelectors.push(r.selector);
+        } else if (isDecorative && hasAlt) {
+          if (decorativeSelectors.length < 20) decorativeSelectors.push(r.selector);
+        }
+        const parentTextNorm = normalize(r.parentText);
+        const altNorm = normalize(alt);
+        if (alt && parentTextNorm && altNorm === parentTextNorm) {
+          if (redundantSelectors.length < 20) redundantSelectors.push(r.selector);
+        }
+        const fname = normalize((r.filename || '').replace(/\.[a-z0-9]+$/, ''));
+        if (alt && fname && altNorm === fname) {
+          if (filenameSelectors.length < 20) filenameSelectors.push(r.selector);
+        }
+        if (r.naturalHeight && r.naturalWidth) {
+          const ratio = r.naturalWidth / r.naturalHeight;
+          if (r.naturalHeight < 50 && ratio > 3) {
+            if (imageOfTextSelectors.length < 20) imageOfTextSelectors.push(r.selector);
+          }
+        }
+      } else if (r.type === 'svg') {
+        stats.svgCount++;
+        const hasLabel = r.hasTitle || r.hasDesc || r.ariaLabel || r.labelledbyText;
+        const isDecorative = ['presentation', 'none'].includes((r.role || '').toLowerCase()) || r.ariaHidden;
+        if (!hasLabel && !isDecorative && (r.inLink || (r.role && r.role !== 'presentation'))) {
+          if (svgMissingTitleSel.length < 20) svgMissingTitleSel.push(r.selector);
+        }
+      } else if (r.type === 'input-image') {
+        const alt = r.alt.trim();
+        if (!alt) {
+          if (inputImageMissingSel.length < 20) inputImageMissingSel.push(r.selector);
+        }
+      } else if (r.type === 'area') {
+        const alt = (r.alt || '').trim();
+        const ariaLabel = (r.ariaLabel || '').trim();
+        if (!alt && !ariaLabel) {
+          if (areaMissingAltSel.length < 20) areaMissingAltSel.push(r.selector);
+        }
+      }
+    }
+
+    if (missingAltSelectors.length) {
+      findings.push({
+        id: 'images:missing-alt',
+        module: 'images',
+        severity: 'serious',
+        summary: 'Image without alt text',
+        details: '',
+        selectors: missingAltSelectors,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (redundantSelectors.length) {
+      findings.push({
+        id: 'images:redundant-alt',
+        module: 'images',
+        severity: 'minor',
+        summary: 'Alt text duplicates nearby text',
+        details: '',
+        selectors: redundantSelectors,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (decorativeSelectors.length) {
+      findings.push({
+        id: 'images:decorative-with-alt',
+        module: 'images',
+        severity: 'minor',
+        summary: 'Decorative image with alt text',
+        details: '',
+        selectors: decorativeSelectors,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (filenameSelectors.length) {
+      findings.push({
+        id: 'images:filename-as-alt',
+        module: 'images',
+        severity: 'minor',
+        summary: 'Alt text equals filename',
+        details: '',
+        selectors: filenameSelectors,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (imageOfTextSelectors.length) {
+      findings.push({
+        id: 'images:image-of-text',
+        module: 'images',
+        severity: 'moderate',
+        summary: 'Image likely contains text',
+        details: '',
+        selectors: imageOfTextSelectors,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.4.5'], bitv: ['1.4.5'] },
+      });
+    }
+    if (svgMissingTitleSel.length) {
+      findings.push({
+        id: 'images:svg-missing-title',
+        module: 'images',
+        severity: 'minor',
+        summary: 'SVG without title/desc',
+        details: '',
+        selectors: svgMissingTitleSel,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (inputImageMissingSel.length) {
+      findings.push({
+        id: 'images:input-image-missing-alt',
+        module: 'images',
+        severity: 'serious',
+        summary: 'Input image without alt',
+        details: '',
+        selectors: inputImageMissingSel,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+    if (areaMissingAltSel.length) {
+      findings.push({
+        id: 'images:imagemap-area-missing-alt',
+        module: 'images',
+        severity: 'serious',
+        summary: 'Image map area without alt',
+        details: '',
+        selectors: areaMissingAltSel,
+        pageUrl: ctx.url,
+        norms: { wcag: ['1.1.1'], bitv: ['1.1.1'] },
+      });
+    }
+
+    const indexPath = await ctx.saveArtifact('images_index.json', raw);
+
+    return {
+      module: 'images',
+      version: '0.1.0',
+      findings,
+      stats,
+      artifacts: { index: indexPath },
+    } as any;
+  },
+};
+
+export default mod;

--- a/backend/profiles/fast.json
+++ b/backend/profiles/fast.json
@@ -4,6 +4,9 @@
       "enabled": true,
       "compareQuery": false,
       "weakTexts": "config/links.weaktexts.de-en.json"
+    },
+    "images": {
+      "enabled": true
     }
   }
 }

--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -75,7 +75,7 @@ function deriveTopFindings(issues: any[], limit = 8) {
   return Array.from(map.values()).sort((a, b) => b.count - a.count).slice(0, limit);
 }
 
-function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport: any[], dynamic: any[], landmarks?: any, headings?: any, links?: any) {
+function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport: any[], dynamic: any[], landmarks?: any, headings?: any, links?: any, images?: any) {
   const regular = issues.filter((v: any) => v.module !== 'landmarks');
   const lmIssues = issues.filter((v: any) => v.module === 'landmarks');
   const rows = regular.slice(0, 300).map((v: any) => {
@@ -110,6 +110,15 @@ function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport
   const linkShare = links ? Math.round((100 - (links.stats?.shareWeak || 0)) * 10) / 10 : 0;
   const linkBadge = links ? badge(linkShare >= 95 ? 'green' : linkShare >= 80 ? 'yellow' : 'red') : '';
   const linkSnippets = links ? (links.hints || []).map((h:any)=>`<h3>${escapeHtml(h.title)}</h3><pre><code>${escapeHtml(h.snippet)}</code></pre>`).join('') : '';
+
+  const imageRows = images ? (images.findings || []).map((v:any)=>{
+    const targets = (v.selectors||[]).slice(0,3).map((sel:string)=>`<code>${escapeHtml(sel)}</code>`).join('<br/>');
+    const wcag = (v.norms?.wcag||[]).join(', ');
+    const bitv = (v.norms?.bitv||[]).join(', ');
+    return `<tr><td><b>${escapeHtml(v.id||'')}</b><br/><small>${escapeHtml(v.summary||'')}</small></td><td>${escapeHtml(v.severity||'n/a')}</td><td><small>WCAG: ${escapeHtml(wcag)}<br/>BITV: ${escapeHtml(bitv)}</small></td><td>${targets}</td></tr>`;
+  }).join('') : '';
+  const imgBadge = images ? (()=>{ const share = images.stats?.total? Math.round((images.stats.missingAlt/images.stats.total)*1000)/10:0; return badge(share<=5?'green':share<=20?'yellow':'red'); })() : '';
+  const svgMissing = images ? (images.findings||[]).filter((f:any)=>f.id==='images:svg-missing-title').length : 0;
 
   const typeCounts: Record<string, number> = {};
   for (const d of downloadsReport || []) {
@@ -153,6 +162,7 @@ function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport
     ${landmarks ? (()=>{ const cov=Math.round(landmarks.metrics?.coverage||0); const b=badge(cov>=95?'green':cov>=80?'yellow':'red'); const snippets=(landmarks.hints||[]).map((h:any)=>`<h3>${escapeHtml(h.title)}</h3><pre><code>${escapeHtml(h.snippet)}</code></pre>`).join(''); return `<h2>Landmarks &amp; Struktur</h2><p>Abdeckung: ${escapeHtml(String(cov))}% ${b}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${lmRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>${snippets?`<details><summary>Behebung</summary>${snippets}</details>`:''}` })() : ''}
     ${headings ? `<h2>Überschriften &amp; Dokumentstruktur</h2><p>H1: ${headings.stats?.hasH1 ? 'ja' : 'nein'} • Mehrfach-H1: ${headings.stats?.multipleH1 ? 'ja' : 'nein'} • Max. Tiefe: ${headings.stats?.maxDepth || 0} • Sprünge: ${headings.stats?.jumps || 0}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${headRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
     ${links ? `<h2>Links &amp; Linktexte</h2><p>Sprechende Linktexte: ${linkShare}% ${linkBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${linkRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>${linkSnippets?`<details><summary>Behebung</summary>${linkSnippets}</details>`:''}` : ''}
+    ${images ? `<h2>Bilder &amp; Alternativtexte</h2><p>Fehlende Alts: ${images.stats?.missingAlt || 0} ${imgBadge} • Dekorativ: ${images.stats?.decorativeCount || 0} • SVG ohne Titel: ${svgMissing}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${imageRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
 
     <h2>Prüfung von Downloads</h2>
     <table>
@@ -170,7 +180,7 @@ function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport
   </body></html>`;
 }
 
-function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: any[], profile: Profile, authority: any, enforcementDataStatus?: string, landmarks?: any, headings?: any, links?: any) {
+function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: any[], profile: Profile, authority: any, enforcementDataStatus?: string, landmarks?: any, headings?: any, links?: any, images?: any) {
   let status = vereinbarkeitsStatus(summary.totals.violations, summary.score.overall);
   if (summary.totals.violations === 0 && !(profile.manualFindings && profile.manualFindings.length)) {
     status = { ...status, code: "unknown" };
@@ -191,6 +201,9 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
   }
   if (links && ((links.stats?.shareWeak || 0) >= 20 || (links.stats?.dupTextGroups || 0) >= 3)) {
     top.unshift({ id: 'links:summary', text: 'Nicht aussagekräftige Linktexte', wcag: ['2.4.4'], count: (links.findings || []).length || 1 });
+  }
+  if (images && (images.stats?.missingAlt || 0) > 0) {
+    top.unshift({ id: 'images:summary', text: 'Bilder ohne Alternativtexte', wcag: ['1.1.1'], count: images.stats.missingAlt });
   }
   const dlIssues = nonLandmarks.filter((v: any) => /^(pdf:|office:|csv:)/.test(v.id || '')); 
   const dlTop = deriveTopFindings(dlIssues, 3);
@@ -217,7 +230,8 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
     "csv:line-endings": "Uneinheitliche Zeilenenden",
     "csv:delimiter-mismatch": "Inkonsistente Trennzeichen",
     "keyboard:focus-indicator-weak": "Fokus-Indikator unzureichend",
-    "keyboard:outline-suppressed": "Fokus-Indikator unterdrückt"
+    "keyboard:outline-suppressed": "Fokus-Indikator unterdrückt",
+    "images:summary": "Bilder ohne Alternativtexte"
   };
 
   const topListBase = top.length
@@ -299,7 +313,7 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
 }
 
 /** Maschinenlesbare Erklärung (vereinfachtes JSON nach EU-Musterempfehlung) */
-function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profile, authority: any, enforcementDataStatus?: string, landmarks?: any, headings?: any, links?: any) {
+function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profile, authority: any, enforcementDataStatus?: string, landmarks?: any, headings?: any, links?: any, images?: any) {
   let status = vereinbarkeitsStatus(summary.totals.violations, summary.score.overall);
   if (summary.totals.violations === 0 && !(profile.manualFindings && profile.manualFindings.length)) {
     status = { ...status, code: "unknown" };
@@ -333,7 +347,8 @@ function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profil
     "csv:line-endings": "Uneinheitliche Zeilenenden",
     "csv:delimiter-mismatch": "Inkonsistente Trennzeichen",
     "keyboard:focus-indicator-weak": "Fokus-Indikator unzureichend",
-    "keyboard:outline-suppressed": "Fokus-Indikator unterdrückt"
+    "keyboard:outline-suppressed": "Fokus-Indikator unterdrückt",
+    "images:summary": "Bilder ohne Alternativtexte"
   };
 
   return {
@@ -360,8 +375,11 @@ function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profil
         if (headings && (headings.findings || []).length) {
           arr.unshift({ id: 'headings:summary', text: 'Unsaubere Überschriftenstruktur (fehlende H1 / Level-Sprünge)', wcag: ['1.3.1','2.4.6'], count: headings.findings.length });
         }
-        if (links && ((links.stats?.shareWeak || 0) >= 20 || (links.stats?.dupTextGroups || 0) >= 3)) {
+  if (links && ((links.stats?.shareWeak || 0) >= 20 || (links.stats?.dupTextGroups || 0) >= 3)) {
           arr.unshift({ id: 'links:summary', text: 'Nicht aussagekräftige Linktexte', wcag: ['2.4.4'], count: (links.findings || []).length || 1 });
+        }
+        if (images && (images.stats?.missingAlt || 0) > 0) {
+          arr.unshift({ id: 'images:summary', text: 'Bilder ohne Alternativtexte', wcag: ['1.1.1'], count: images.stats.missingAlt });
         }
         return arr;
       })()
@@ -437,15 +455,16 @@ export async function main() {
     }
     // HTML bauen
     const links = results.modules?.['links'];
-    const internalHtml = renderInternalHTML(summary, issues, downloadsReport, dynamicInteractions, landmarks, headings, links);
-    const publicHtml = renderPublicHTML(summary, issues, downloadsReport, profile, authority, enforcementDataStatus, landmarks, headings, links);
+    const images = results.modules?.['images'];
+    const internalHtml = renderInternalHTML(summary, issues, downloadsReport, dynamicInteractions, landmarks, headings, links, images);
+    const publicHtml = renderPublicHTML(summary, issues, downloadsReport, profile, authority, enforcementDataStatus, landmarks, headings, links, images);
 
     // HTML speichern
   await fs.writeFile(path.join(outDir, "report_internal.html"), internalHtml, "utf-8");
   await fs.writeFile(path.join(outDir, "report_public.html"), publicHtml, "utf-8");
 
   // JSON-Erklärung speichern (maschinenlesbar)
-    const statementJson = buildStatementJSON(summary, issues, profile, authority, enforcementDataStatus, landmarks, headings, links);
+    const statementJson = buildStatementJSON(summary, issues, profile, authority, enforcementDataStatus, landmarks, headings, links, images);
   await fs.writeFile(path.join(outDir, "public_statement.json"), JSON.stringify(statementJson, null, 2), "utf-8");
 
   // PDF drucken

--- a/backend/tests/fixtures/images/index.html
+++ b/backend/tests/fixtures/images/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html><body>
+<img src="a.jpg" width="100" height="20">
+<img src="b.jpg" role="presentation" alt="decor" width="10" height="10">
+<a href="#"><img src="c.jpg" alt="Link" width="10" height="10">Link</a>
+<img src="foo.jpg" alt="foo" width="10" height="10">
+<a href="#"><svg width="10" height="10"></svg></a>
+<img src="map.png" usemap="#m" width="10" height="10">
+<map name="m"><area shape="rect" coords="0,0,10,10"></map>
+<input type="image" src="submit.png" width="10" height="10">
+</body></html>

--- a/backend/tests/images.test.ts
+++ b/backend/tests/images.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { chromium } from 'playwright';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import mod from '../modules/images/index.ts';
+import { main as engineMain } from '../core/engine.js';
+import { main as buildReports } from '../scripts/build-reports.js';
+
+async function runWithRaw(raw: any[]) {
+  const ctx: any = {
+    page: { evaluate: async () => raw },
+    url: 'http://example.com',
+    crawlGraph: [],
+    config: { modules: { images: {} } },
+    log() {},
+    saveArtifact: async () => ''
+  };
+  return await mod.run(ctx);
+}
+
+test('detect various image issues', async () => {
+  const raw = [
+    { type: 'img', alt: null, src: 'a.jpg', role: '', ariaHidden: false, selector: 'img:nth-of-type(1)', filename: 'a.jpg', parentText: '', naturalWidth: 100, naturalHeight: 20 },
+    { type: 'img', alt: 'decor', src: 'b.jpg', role: 'presentation', ariaHidden: false, selector: 'img:nth-of-type(2)', filename: 'b.jpg', parentText: '', naturalWidth: 10, naturalHeight: 10 },
+    { type: 'img', alt: 'Home', src: 'c.jpg', role: '', ariaHidden: false, selector: 'img:nth-of-type(3)', filename: 'c.jpg', parentText: 'Home', naturalWidth: 10, naturalHeight: 10 },
+    { type: 'img', alt: 'foo', src: 'foo.jpg', role: '', ariaHidden: false, selector: 'img:nth-of-type(4)', filename: 'foo.jpg', parentText: '', naturalWidth: 10, naturalHeight: 10 },
+    { type: 'svg', hasTitle: false, hasDesc: false, ariaLabel: '', labelledbyText: '', role: '', ariaHidden: false, selector: 'svg:nth-of-type(1)', inLink: true },
+    { type: 'input-image', alt: '', src: 'submit.png', selector: 'input:nth-of-type(1)' },
+    { type: 'area', alt: '', ariaLabel: '', selector: 'area:nth-of-type(1)' }
+  ];
+  const res = await runWithRaw(raw);
+  const ids = res.findings.map((f: any) => f.id);
+  assert.ok(ids.includes('images:missing-alt'));
+  assert.ok(ids.includes('images:decorative-with-alt'));
+  assert.ok(ids.includes('images:redundant-alt'));
+  assert.ok(ids.includes('images:filename-as-alt'));
+  assert.ok(ids.includes('images:svg-missing-title'));
+  assert.ok(ids.includes('images:input-image-missing-alt'));
+  assert.ok(ids.includes('images:imagemap-area-missing-alt'));
+});
+
+test('engine processes local fixture with images module', async (t) => {
+  const fileUrl = 'file://' + path.join(process.cwd(), 'tests', 'fixtures', 'images', 'index.html');
+  let results: any;
+  const orig = process.argv;
+  process.argv = process.argv.slice(0,2).concat(['--url', fileUrl, '--profile', 'fast']);
+  try {
+    results = await engineMain();
+  } catch (e) {
+    t.skip(`Engine run failed: ${e}`);
+    return;
+  } finally {
+    process.argv = orig;
+  }
+  const imgMod = results.modules['images'];
+  if (!imgMod) {
+    t.skip('images module missing');
+    return;
+  }
+  assert.ok(imgMod.findings.some((f: any) => f.id === 'images:missing-alt'));
+  const idxPath = path.join(process.cwd(), 'out', 'images_index.json');
+  const idx = JSON.parse(await fs.readFile(idxPath, 'utf-8'));
+  assert.ok(Array.isArray(idx) && idx.length > 0);
+  const fakePage = { setViewportSize() {}, setContent() {}, pdf: async () => {} } as any;
+  const fakeBrowser = { newPage: async () => fakePage, close: async () => {} } as any;
+  t.mock.method(chromium, 'launch', async () => fakeBrowser);
+  await buildReports();
+  const report = await fs.readFile(path.join(process.cwd(), 'out', 'report_internal.html'), 'utf-8');
+  assert.ok(/Bilder &amp; Alternativtexte/.test(report));
+});


### PR DESCRIPTION
## Summary
- add `images` module to check alt text and SVG labeling
- support `--no-images` flag and enable module in fast profile
- include image metrics in internal/public reports

## Testing
- `npm test` *(fails: page.goto: net::ERR_CERT_AUTHORITY_INVALID)*
- `npx tsx --test tests/images.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68ac28c92e84832ca42d91b02148a2d8