### PR TITLE
feat(meta): page-title and document-language checks (WCAG 2.4.2, 3.1.1)

### DIFF
--- a/backend/core/types.ts
+++ b/backend/core/types.ts
@@ -1,4 +1,4 @@
-export type Severity = 'critical' | 'serious' | 'moderate' | 'minor';
+export type Severity = 'critical' | 'serious' | 'moderate' | 'minor' | 'advice';
 
 export interface NormRefs {
   wcag?: string[];

--- a/backend/modules/metaDoc/index.ts
+++ b/backend/modules/metaDoc/index.ts
@@ -124,7 +124,7 @@ const mod: Module = {
         findings.push({
           id: 'meta:lang-content-mismatch',
           module: 'metaDoc',
-          severity: 'minor',
+          severity: 'advice',
           summary: `Content language seems to be ${detected}`,
           details: '',
           selectors: ['html'],

--- a/backend/tests/meta-doc.test.ts
+++ b/backend/tests/meta-doc.test.ts
@@ -44,6 +44,12 @@ test('fixture E: lang vs xml:lang mismatch', async () => {
   assert.ok(res.findings.some((f:any)=>f.id==='meta:lang-xml-mismatch'));
 });
 
+test('fixture F: lang/content mismatch', async () => {
+  const html = '<html lang="de"><head><title>Hallo Welt</title></head><body>The and not is this that with from</body></html>';
+  const res = await runSnippet(html);
+  assert.ok(res.findings.some((f:any)=>f.id==='meta:lang-content-mismatch' && f.severity==='advice'));
+});
+
 test('e2e BAD demo site includes metaDoc section', async (t) => {
   const TEST_URL = 'https://www.w3.org/WAI/demos/bad/';
   const orig = process.argv;


### PR DESCRIPTION
## Summary
- flag content language mismatches as advisory
- test meta-doc against mismatching lang/content
- support `advice` severity level in findings

## Testing
- `npm run build`
- `npm test` *(fails: page.goto: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7dc1de04832ca3050bdc5986289f