### PR TITLE
feat(meta): add page-title and document-language checks (WCAG 2.4.2, 3.1.1)

### DIFF
--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -175,7 +175,7 @@ function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport
       <tbody>${rows || '<tr><td colspan="4"><small>Keine Verstöße ermittelt.</small></td></tr>'}</tbody>
     </table>
 
-    ${metaDoc ? `<h2>Dokumentsprache &amp; Titel</h2><p>Sprache: ${escapeHtml(metaDoc.stats?.lang || '-') } ${langBadge} • Titel-Länge: ${metaDoc.stats?.titleLength || 0} ${titleBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${metaRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
+    ${metaDoc ? `<h2>Dokumentsprache &amp; Seitentitel</h2><p>Sprache: ${escapeHtml(metaDoc.stats?.lang || '-') } ${langBadge} • Titel-Länge: ${metaDoc.stats?.titleLength || 0} ${titleBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${metaRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
     ${landmarks ? (()=>{ const cov=Math.round(landmarks.metrics?.coverage||0); const b=badge(cov>=95?'green':cov>=80?'yellow':'red'); const snippets=(landmarks.hints||[]).map((h:any)=>`<h3>${escapeHtml(h.title)}</h3><pre><code>${escapeHtml(h.snippet)}</code></pre>`).join(''); return `<h2>Landmarks &amp; Struktur</h2><p>Abdeckung: ${escapeHtml(String(cov))}% ${b}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${lmRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>${snippets?`<details><summary>Behebung</summary>${snippets}</details>`:''}` })() : ''}
     ${headings ? `<h2>Überschriften &amp; Dokumentstruktur</h2><p>H1: ${headings.stats?.hasH1 ? 'ja' : 'nein'} • Mehrfach-H1: ${headings.stats?.multipleH1 ? 'ja' : 'nein'} • Max. Tiefe: ${headings.stats?.maxDepth || 0} • Sprünge: ${headings.stats?.jumps || 0}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${headRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
     ${skiplinks ? `<h2>Skip-Links &amp; Sprungziele</h2><p>Skip-Links: ${skiplinks.stats?.total || 0} ${skipBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${skipRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
@@ -303,7 +303,7 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
     const rows = (metaDoc.findings || []).map((v:any) => `<li>${escapeHtml(plainMap[v.id] || v.summary || '')}${v.norms?.wcag?.length?` (WCAG: ${escapeHtml(v.norms.wcag.join(', '))})`:''}</li>`).join('');
     const lBadge = badge(metaDoc.stats?.langValid ? 'green' : metaDoc.stats?.lang ? 'yellow' : 'red');
     const tBadge = badge(metaDoc.stats?.titleLength >= 10 ? 'green' : metaDoc.stats?.titleLength ? 'yellow' : 'red');
-    return `<h2>Dokumentsprache &amp; Titel</h2><p>Sprache: ${escapeHtml(metaDoc.stats?.lang || '-') } ${lBadge} • Titel-Länge: ${metaDoc.stats?.titleLength || 0} ${tBadge}</p>${rows ? `<ul>${rows}</ul>` : '<p><small>Keine Befunde.</small></p>'}`;
+    return `<h2>Dokumentsprache &amp; Seitentitel</h2><p>Sprache: ${escapeHtml(metaDoc.stats?.lang || '-') } ${lBadge} • Titel-Länge: ${metaDoc.stats?.titleLength || 0} ${tBadge}</p>${rows ? `<ul>${rows}</ul>` : '<p><small>Keine Befunde.</small></p>'}`;
   })() : '';
 
   const manual = (profile.manualFindings || []).map((m) =>

--- a/backend/tests/meta-doc.test.ts
+++ b/backend/tests/meta-doc.test.ts
@@ -70,7 +70,7 @@ test('e2e BAD demo site includes metaDoc section', async (t) => {
   t.mock.method(chromium, 'launch', async () => fakeBrowser);
   await buildReports();
   const reportInt = await fs.readFile(path.join(process.cwd(), 'out', 'report_internal.html'), 'utf-8');
-  assert.ok(/Dokumentsprache &amp; Titel/.test(reportInt));
+  assert.ok(/Dokumentsprache &amp; Seitentitel/.test(reportInt));
   const reportPub = await fs.readFile(path.join(process.cwd(), 'out', 'report_public.html'), 'utf-8');
-  assert.ok(/Dokumentsprache &amp; Titel/.test(reportPub));
+  assert.ok(/Dokumentsprache &amp; Seitentitel/.test(reportPub));
 });


### PR DESCRIPTION
## Summary
- rename report section to "Dokumentsprache & Seitentitel"
- update meta doc e2e test for new section title

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'modules'))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ae9b818ff0832c8df56efc2f68f219