### PR TITLE
feat(forms): deepen checks for labels, error association, required indication, grouping, and autocomplete

### DIFF
--- a/backend/tests/fixtures/forms/a-ok.html
+++ b/backend/tests/fixtures/forms/a-ok.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html><body>
+<form>
+  <label for="name">Name</label>
+  <input id="name" type="text" />
+  <fieldset>
+    <legend>Choice</legend>
+    <label><input type="radio" name="g" value="a" />A</label>
+    <label><input type="radio" name="g" value="b" />B</label>
+  </fieldset>
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/autocomplete-wrong.html
+++ b/backend/tests/fixtures/forms/autocomplete-wrong.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html><body>
+<form>
+  <label for="mail">Email</label>
+  <input id="mail" type="text" />
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/error-not-associated.html
+++ b/backend/tests/fixtures/forms/error-not-associated.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html><body>
+<form>
+  <label for="f">Field</label>
+  <input id="f" aria-invalid="true" />
+  <div class="error">Error message</div>
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/missing-label.html
+++ b/backend/tests/fixtures/forms/missing-label.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html><body>
+<form>
+  <input id="noLabel" type="text" />
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/multiple-labels.html
+++ b/backend/tests/fixtures/forms/multiple-labels.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html><body>
+<form>
+  <label for="f">First</label>
+  <label>Second <input id="f" type="text" /></label>
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/radio-group-no-fieldset.html
+++ b/backend/tests/fixtures/forms/radio-group-no-fieldset.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html><body>
+<form>
+  <label><input type="radio" name="g" value="1" />One</label>
+  <label><input type="radio" name="g" value="2" />Two</label>
+</form>
+</body></html>

--- a/backend/tests/fixtures/forms/required-not-indicated.html
+++ b/backend/tests/fixtures/forms/required-not-indicated.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html><body>
+<form>
+  <label for="f">Name</label>
+  <input id="f" required aria-describedby="f_err" />
+  <div id="f_err" role="alert"></div>
+</form>
+</body></html>

--- a/backend/tests/forms.fixtures.test.ts
+++ b/backend/tests/forms.fixtures.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { chromium } from 'playwright';
+import mod from '../modules/forms/index.ts';
+import { getNameInfo } from '../src/a11y/name.ts';
+
+async function runFixture(file: string) {
+  const html = await fs.readFile(path.join(process.cwd(), 'tests', 'fixtures', 'forms', file), 'utf-8');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.setContent(html);
+  // inject helper used by collectFormControls
+  await page.addScriptTag({ content: `${getNameInfo.toString()}` });
+  const artifacts: Record<string, any> = {};
+  const ctx: any = { page, url: 'http://example.com', crawlGraph: [], config: { modules: { forms: {} } }, log() {}, saveArtifact: async (name: string, data: any) => { artifacts[name] = data; return name; } };
+  const res = await mod.run(ctx);
+  await browser.close();
+  return { res, artifacts };
+}
+
+test('a-ok.html yields no findings and creates overview artifact', async () => {
+  const { res, artifacts } = await runFixture('a-ok.html');
+  assert.strictEqual(res.findings.length, 0);
+  const overview = artifacts['forms_overview.json'];
+  assert.ok(Array.isArray(overview) && overview.length > 0);
+  const first = overview[0];
+  assert.ok('type' in first && 'labels' in first);
+});
+
+test('missing-label.html reports missing-label', async () => {
+  const { res } = await runFixture('missing-label.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:missing-label'));
+});
+
+test('multiple-labels.html reports multiple-labels', async () => {
+  const { res } = await runFixture('multiple-labels.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:multiple-labels'));
+});
+
+test('error-not-associated.html reports error-not-associated', async () => {
+  const { res } = await runFixture('error-not-associated.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:error-not-associated'));
+});
+
+test('required-not-indicated.html reports required-not-indicated', async () => {
+  const { res } = await runFixture('required-not-indicated.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:required-not-indicated'));
+});
+
+test('radio-group-no-fieldset.html reports missing-fieldset-legend', async () => {
+  const { res } = await runFixture('radio-group-no-fieldset.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:missing-fieldset-legend'));
+});
+
+test('autocomplete-wrong.html reports autocomplete-missing-or-wrong', async () => {
+  const { res } = await runFixture('autocomplete-wrong.html');
+  assert.strictEqual(res.findings.length, 1);
+  assert.ok(res.findings.some((f: any) => f.id === 'forms:autocomplete-missing-or-wrong'));
+});


### PR DESCRIPTION
## Summary
- add fixtures covering typical form issues like missing labels, unbound errors, unclear required indicators, absent grouping, and autocomplete hints
- introduce unit tests validating forms module findings and overview artifact

## Testing
- `npx tsx --test tests/forms.fixtures.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68aebb3c50a8832ca0bc215beb68e9f5