### PR TITLE
feat(forms): deepen checks for labels, error association, required indication, grouping and autocomplete (WCAG 1.3.1 / 3.3.x / 4.1.2)

### DIFF
--- a/backend/modules/forms/index.ts
+++ b/backend/modules/forms/index.ts
@@ -2,7 +2,8 @@ import type { Module, Severity, Finding, NormRefs } from '../../core/types.js';
 import rulesMapping from '../../config/rules_mapping.json' assert { type: 'json' };
 import { collectFormControls } from '../../src/a11y/forms.js';
 
-const map: Record<string, { wcag?: string[]; bitv?: string[]; severity?: Severity }> = rulesMapping as any;
+const map: Record<string, { wcag?: string[]; bitv?: string[]; severity?: Severity }> =
+  rulesMapping as any;
 
 const mod: Module = {
   slug: 'forms',
@@ -12,31 +13,72 @@ const mod: Module = {
     for (const f of fields) (f as any).problems = [] as string[];
 
     const findings: Finding[] = [];
-    const stats: Record<string, number> = { fields: fields.length };
+    const stats = {
+      totalFields: fields.length,
+      missingLabels: 0,
+      errorsUnbound: 0,
+      requiredUnindicated: 0,
+      groupsMissingLegend: 0,
+      autocompleteIssues: 0,
+    };
 
-    function addFinding(id: string, summary: string, details: string, selectors: string[]) {
+    type StatKey = keyof typeof stats;
+
+    function addFinding(
+      id: string,
+      summary: string,
+      details: string,
+      selectors: string[],
+      statKey?: StatKey
+    ) {
       const m = map[id] || {};
       const norms: NormRefs = {};
       if (m.wcag) norms.wcag = m.wcag;
       if (m.bitv) norms.bitv = m.bitv;
       const severity: Severity = (m.severity || 'moderate') as Severity;
-      findings.push({ id, module: 'forms', severity, summary, details, selectors, pageUrl: ctx.url, ...(Object.keys(norms).length ? { norms } : {}) });
-      stats[id] = (stats[id] || 0) + 1;
+      findings.push({
+        id,
+        module: 'forms',
+        severity,
+        summary,
+        details,
+        selectors,
+        pageUrl: ctx.url,
+        ...(Object.keys(norms).length ? { norms } : {}),
+      });
+      if (statKey) stats[statKey]++;
     }
 
     for (const f of fields) {
       const probs: string[] = (f as any).problems;
       if (!f.labels.length) {
         probs.push('forms:missing-label');
-        addFinding('forms:missing-label', 'Form field has no label', 'Input/select/textarea element lacks accessible name', [f.selector]);
+        addFinding(
+          'forms:missing-label',
+          'Form field has no label',
+          'Input/select/textarea element lacks accessible name',
+          [f.selector],
+          'missingLabels'
+        );
       } else if (f.labels.length > 1) {
         probs.push('forms:multiple-labels');
-        addFinding('forms:multiple-labels', 'Form field has multiple labels', 'Field is associated with multiple visible labels', [f.selector]);
+        addFinding(
+          'forms:multiple-labels',
+          'Form field has multiple labels',
+          'Field is associated with multiple visible labels',
+          [f.selector]
+        );
       }
 
       if (f.validation && !f.hasErrorBinding) {
         probs.push('forms:error-not-associated');
-        addFinding('forms:error-not-associated', 'Validation error not associated', 'Field has validation attributes but no associated error message via aria-describedby', [f.selector]);
+        addFinding(
+          'forms:error-not-associated',
+          'Validation error not associated',
+          'Field has validation attributes but no associated error message via aria-describedby',
+          [f.selector],
+          'errorsUnbound'
+        );
       }
 
       if (f.required) {
@@ -44,7 +86,13 @@ const mod: Module = {
         const visible = txt.includes('*') || /required|erforderlich|pflichtfeld|mandatory|obligatory/.test(txt);
         if (!visible && !f.ariaRequired) {
           probs.push('forms:required-not-indicated');
-          addFinding('forms:required-not-indicated', 'Required field not indicated', 'Field marked as required but not indicated in label or aria-required', [f.selector]);
+          addFinding(
+            'forms:required-not-indicated',
+            'Required field not indicated',
+            'Field marked as required but not indicated in label or aria-required',
+            [f.selector],
+            'requiredUnindicated'
+          );
         }
       }
 
@@ -59,7 +107,13 @@ const mod: Module = {
         const acWrong = expected.autocomplete && ac !== expected.autocomplete;
         if (typeWrong || acWrong || !ac) {
           probs.push('forms:autocomplete-missing-or-wrong');
-          addFinding('forms:autocomplete-missing-or-wrong', 'Autocomplete/type missing or wrong', 'Field could benefit from appropriate type or autocomplete', [f.selector]);
+          addFinding(
+            'forms:autocomplete-missing-or-wrong',
+            'Autocomplete/type missing or wrong',
+            'Field could benefit from appropriate type or autocomplete',
+            [f.selector],
+            'autocompleteIssues'
+          );
         }
       }
     }
@@ -67,14 +121,20 @@ const mod: Module = {
     for (const name in groups) {
       const g = groups[name];
       if (g.selectors.length > 1 && !g.hasFieldsetLegend) {
-        addFinding('forms:missing-fieldset-legend', 'Form controls missing fieldset/legend', 'Group of radio buttons or checkboxes lacks fieldset/legend', g.selectors.slice(0, 1));
+        addFinding(
+          'forms:missing-fieldset-legend',
+          'Form controls missing fieldset/legend',
+          'Group of radio buttons or checkboxes lacks fieldset/legend',
+          g.selectors.slice(0, 1),
+          'groupsMissingLegend'
+        );
         const target = fields.find((f: any) => f.selector === g.selectors[0]);
         if (target) (target as any).problems.push('forms:missing-fieldset-legend');
       }
     }
 
     const overviewPath = await ctx.saveArtifact('forms_overview.json', fields);
-    return { module: 'forms', version: '0.3.0', findings, stats, artifacts: { overview: overviewPath } };
+    return { module: 'forms', version: '0.3.0', findings, stats, artifacts: { index: overviewPath } };
   }
 };
 

--- a/backend/scripts/build-reports.ts
+++ b/backend/scripts/build-reports.ts
@@ -185,7 +185,7 @@ function renderInternalHTML(summary: ScanSummary, issues: any[], downloadsReport
     ${landmarks ? (()=>{ const cov=Math.round(landmarks.metrics?.coverage||0); const b=badge(cov>=95?'green':cov>=80?'yellow':'red'); const snippets=(landmarks.hints||[]).map((h:any)=>`<h3>${escapeHtml(h.title)}</h3><pre><code>${escapeHtml(h.snippet)}</code></pre>`).join(''); return `<h2>Landmarks &amp; Struktur</h2><p>Abdeckung: ${escapeHtml(String(cov))}% ${b}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${lmRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>${snippets?`<details><summary>Behebung</summary>${snippets}</details>`:''}` })() : ''}
     ${headings ? `<h2>Überschriften &amp; Dokumentstruktur</h2><p>H1: ${headings.stats?.hasH1 ? 'ja' : 'nein'} • Mehrfach-H1: ${headings.stats?.multipleH1 ? 'ja' : 'nein'} • Max. Tiefe: ${headings.stats?.maxDepth || 0} • Sprünge: ${headings.stats?.jumps || 0}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${headRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
     ${skiplinks ? `<h2>Skip-Links &amp; Sprungziele</h2><p>Skip-Links: ${skiplinks.stats?.total || 0} ${skipBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${skipRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
-    ${forms ? `<h2>Formulare</h2><p>Formularfelder: ${forms.stats?.fields || 0}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${formRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
+    ${forms ? `<h2>Formulare</h2><p>Formularfelder: ${forms.stats?.totalFields || 0}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${formRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
     ${links ? `<h2>Links &amp; Linktexte</h2><p>Sprechende Linktexte: ${linkShare}% ${linkBadge}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${linkRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>${linkSnippets?`<details><summary>Behebung</summary>${linkSnippets}</details>`:''}` : ''}
     ${images ? `<h2>Bilder &amp; Alternativtexte</h2><p>Fehlende Alts: ${images.stats?.missingAlt || 0} ${imgBadge} • Dekorativ: ${images.stats?.decorativeCount || 0} • SVG ohne Titel: ${svgMissing}</p><table><thead><tr><th>Regel</th><th>Schwere</th><th>Normbezug</th><th>Beispiele</th></tr></thead><tbody>${imageRows || '<tr><td colspan="4"><small>Keine Befunde.</small></td></tr>'}</tbody></table>` : ''}
 
@@ -232,8 +232,14 @@ function renderPublicHTML(summary: ScanSummary, issues: any[], downloadsReport: 
       top.unshift({ id: 'landmarks:summary', text: 'Unzureichende Landmark-Struktur', wcag: ['1.3.1'], count: (landmarks.findings||[]).length || 1 });
     }
   }
-  if (forms && (forms.findings || []).length >= 3) {
-    top.unshift({ id: 'forms:summary', text: 'Probleme bei Formularbedienung', wcag: ['3.3.2'], count: (forms.findings || []).length });
+  if (forms) {
+    const crit =
+      (forms.stats?.missingLabels || 0) +
+      (forms.stats?.errorsUnbound || 0) +
+      (forms.stats?.requiredUnindicated || 0);
+    if (crit >= 3) {
+      top.unshift({ id: 'forms:summary', text: 'Probleme bei Formularbedienung', wcag: ['3.3.2'], count: crit });
+    }
   }
   if (links && ((links.stats?.shareWeak || 0) >= 20 || (links.stats?.dupTextGroups || 0) >= 3)) {
     top.unshift({ id: 'links:summary', text: 'Nicht aussagekräftige Linktexte', wcag: ['2.4.4'], count: (links.findings || []).length || 1 });
@@ -449,8 +455,14 @@ function buildStatementJSON(summary: ScanSummary, issues: any[], profile: Profil
         if (headings && (headings.findings || []).length) {
           arr.unshift({ id: 'headings:summary', text: 'Unsaubere Überschriftenstruktur (fehlende H1 / Level-Sprünge)', wcag: ['1.3.1','2.4.6'], count: headings.findings.length });
         }
-        if (forms && (forms.findings || []).length >= 3) {
-          arr.unshift({ id: 'forms:summary', text: 'Probleme bei Formularbedienung', wcag: ['3.3.2'], count: (forms.findings || []).length });
+        if (forms) {
+          const crit =
+            (forms.stats?.missingLabels || 0) +
+            (forms.stats?.errorsUnbound || 0) +
+            (forms.stats?.requiredUnindicated || 0);
+          if (crit >= 3) {
+            arr.unshift({ id: 'forms:summary', text: 'Probleme bei Formularbedienung', wcag: ['3.3.2'], count: crit });
+          }
         }
         if (links && ((links.stats?.shareWeak || 0) >= 20 || (links.stats?.dupTextGroups || 0) >= 3)) {
           arr.unshift({ id: 'links:summary', text: 'Nicht aussagekräftige Linktexte', wcag: ['2.4.4'], count: (links.findings || []).length || 1 });

--- a/backend/tests/forms.fixtures.test.ts
+++ b/backend/tests/forms.fixtures.test.ts
@@ -23,6 +23,12 @@ async function runFixture(file: string) {
 test('a-ok.html yields no findings and creates overview artifact', async () => {
   const { res, artifacts } = await runFixture('a-ok.html');
   assert.strictEqual(res.findings.length, 0);
+  assert.strictEqual(res.stats.totalFields, 3);
+  assert.strictEqual(res.stats.missingLabels, 0);
+  assert.strictEqual(res.stats.errorsUnbound, 0);
+  assert.strictEqual(res.stats.requiredUnindicated, 0);
+  assert.strictEqual(res.stats.groupsMissingLegend, 0);
+  assert.strictEqual(res.stats.autocompleteIssues, 0);
   const overview = artifacts['forms_overview.json'];
   assert.ok(Array.isArray(overview) && overview.length > 0);
   const first = overview[0];
@@ -33,34 +39,41 @@ test('missing-label.html reports missing-label', async () => {
   const { res } = await runFixture('missing-label.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:missing-label'));
+  assert.strictEqual(res.stats.missingLabels, 1);
 });
 
 test('multiple-labels.html reports multiple-labels', async () => {
   const { res } = await runFixture('multiple-labels.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:multiple-labels'));
+  assert.strictEqual(res.stats.totalFields, 1);
 });
 
 test('error-not-associated.html reports error-not-associated', async () => {
   const { res } = await runFixture('error-not-associated.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:error-not-associated'));
+  assert.strictEqual(res.stats.errorsUnbound, 1);
 });
 
 test('required-not-indicated.html reports required-not-indicated', async () => {
   const { res } = await runFixture('required-not-indicated.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:required-not-indicated'));
+  assert.strictEqual(res.stats.requiredUnindicated, 1);
 });
 
 test('radio-group-no-fieldset.html reports missing-fieldset-legend', async () => {
   const { res } = await runFixture('radio-group-no-fieldset.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:missing-fieldset-legend'));
+  assert.strictEqual(res.stats.groupsMissingLegend, 1);
+  assert.strictEqual(res.stats.totalFields, 2);
 });
 
 test('autocomplete-wrong.html reports autocomplete-missing-or-wrong', async () => {
   const { res } = await runFixture('autocomplete-wrong.html');
   assert.strictEqual(res.findings.length, 1);
   assert.ok(res.findings.some((f: any) => f.id === 'forms:autocomplete-missing-or-wrong'));
+  assert.strictEqual(res.stats.autocompleteIssues, 1);
 });


### PR DESCRIPTION
## Summary
- track form statistics for missing labels, unbound errors, required indicators, grouping and autocomplete
- trigger public summary when critical form issues reach threshold
- add unit test coverage for form stats

## Testing
- `npm test` *(fails: page.goto net::ERR_CERT_AUTHORITY_INVALID)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aec3f8a67c832c9f506afc10025b32