### PR TITLE
feat(meta): page-title & document-language checks (WCAG 2.4.2 / 3.1.1)

### DIFF
--- a/backend/modules/meta-doc/index.ts
+++ b/backend/modules/meta-doc/index.ts
@@ -15,7 +15,7 @@ const mod: Module = {
       const title = (document.querySelector('title')?.textContent || '').trim();
       const lang = (document.documentElement.getAttribute('lang') || '').trim().toLowerCase();
       const xmlLang = (document.documentElement.getAttribute('xml:lang') || '').trim().toLowerCase();
-      const metaCharset = document.querySelector('meta[charset]')?.getAttribute('charset') || '';
+      const charset = document.querySelector('meta[charset]')?.getAttribute('charset') || '';
       const navLang = (navigator.language || '').trim().toLowerCase();
       const langCounts: Record<string, number> = {};
       for (const el of Array.from(document.querySelectorAll('[lang]'))) {
@@ -24,7 +24,7 @@ const mod: Module = {
         langCounts[l] = (langCounts[l] || 0) + 1;
       }
       const domLang = Object.entries(langCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || '';
-      return { title, lang, xmlLang, metaCharset, navLang, domLang };
+      return { title, lang, xmlLang, charset, navLang, domLang };
     });
 
     const stats: any = {
@@ -33,7 +33,7 @@ const mod: Module = {
       lang: raw.lang || undefined,
       xmlLang: raw.xmlLang || undefined,
       langValid: true,
-      metaCharset: raw.metaCharset || undefined,
+      charset: raw.charset || undefined,
     };
 
     const findings: Finding[] = [];

--- a/backend/tests/meta-doc.test.ts
+++ b/backend/tests/meta-doc.test.ts
@@ -23,6 +23,7 @@ test('fixture A: valid title and lang', async () => {
   assert.equal(res.findings.length, 0);
   assert.equal(res.stats.lang, 'en');
   assert.equal(res.stats.hasTitle, true);
+  assert.equal(res.stats.charset, undefined);
 });
 
 test('fixture B: missing title', async () => {


### PR DESCRIPTION
## Summary
- collect `<meta charset>` and expose as `stats.charset` in meta-doc module
- verify charset capture in meta-doc unit test

## Testing
- `npm run build`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_b_68b053f9f618832c91c2fd89e444f4ba