### PR TITLE
feat(meta): add page-title and document-language checks (WCAG 2.4.2 / 3.1.1)

### DIFF
--- a/backend/modules/meta-doc/index.ts
+++ b/backend/modules/meta-doc/index.ts
@@ -1,15 +1,17 @@
 import type { Module, Finding } from '../../core/types.js';
 
+export const defaultConfig = { minTitleLength: 10, enableContentHeuristics: false };
+
 const mod: Module = {
   slug: 'meta-doc',
   version: '0.1.0',
   async run(ctx) {
     const cfg =
       ctx.config.modules?.['meta-doc'] && typeof (ctx.config.modules as any)['meta-doc'] === 'object'
-        ? (ctx.config.modules as any)['meta-doc']
-        : {};
-    const minTitle = cfg.minTitleLength ?? 10;
-    const enableHeuristics = cfg.enableContentHeuristics ?? false;
+        ? { ...defaultConfig, ...(ctx.config.modules as any)['meta-doc'] }
+        : defaultConfig;
+    const minTitle = cfg.minTitleLength;
+    const enableHeuristics = cfg.enableContentHeuristics;
 
     const raw = await ctx.page.evaluate(() => {
       const title = (document.querySelector('title')?.textContent || '').trim();


### PR DESCRIPTION
## Summary
- export default configuration for meta-doc module
- continue to validate page titles and document language against WCAG 2.4.2/3.1.1

## Testing
- `npm test` *(fails: expected heading findings)*

------
https://chatgpt.com/codex/tasks/task_b_68b05b257f70832cb616edd1bff0065e