### PR TITLE
feat(downloads): add deep checks for PDF/Office/CSV/TXT and wire into reports

### DIFF
--- a/backend/scanners/downloads.ts
+++ b/backend/scanners/downloads.ts
@@ -14,35 +14,49 @@ export async function analyzePdf(buf: Buffer) {
   const tagged = /\/StructTreeRoot/.test(txt) && /\/MarkInfo\s*<<?[^>]*\/Marked\s*true/i.test(txt);
   const hasLang = Boolean(meta.info?.Lang || /\/Lang\s*\([^)]*\)/i.test(txt));
   const hasTitle = Boolean(meta.info?.Title || /\/Title\s*\([^)]*\)/.test(txt));
-  return { tagged, hasLang, hasTitle, pages };
+  const hasOutline = /\/Outlines\s+\d+\s+0\s+R/.test(txt);
+  return { tagged, hasLang, hasTitle, hasOutline, pages };
 }
 
 /** Inspect OOXML (docx/xlsx/pptx) for simple accessibility hints. */
 export async function analyzeOffice(buf: Buffer, kind: 'docx'|'xlsx'|'pptx') {
   const zip = await unzipper.Open.buffer(buf);
   const paths = zip.files.map(f => f.path);
-  const hasCore = paths.includes('docProps/core.xml');
-  let imageRelCount = 0;
-  if (kind === 'pptx') {
-    for (const f of zip.files) {
-      if (f.path.startsWith('ppt/slides/_rels/') && f.path.endsWith('.rels')) {
-        const content = await f.buffer();
-        const txt = content.toString('utf-8');
-        imageRelCount += (txt.match(/Target="..\/media\//g) || []).length;
-      }
+  const coreFile = zip.files.find(f => f.path === 'docProps/core.xml');
+  let title = '';
+  let creator = '';
+  let subject = '';
+  if (coreFile) {
+    const coreTxt = (await coreFile.buffer()).toString('utf-8');
+    title = (coreTxt.match(/<dc:title>([^<]*)<\/dc:title>/)?.[1] || '').trim();
+    creator = (coreTxt.match(/<dc:creator>([^<]*)<\/dc:creator>/)?.[1] || '').trim();
+    subject = (coreTxt.match(/<dc:subject>([^<]*)<\/dc:subject>/)?.[1] || '').trim();
+  }
+  let slideCount = 0;
+  let sheetCount = 0;
+  let hasAltTextHints = false;
+  for (const f of zip.files) {
+    if (kind === 'pptx' && f.path.startsWith('ppt/slides/slide') && f.path.endsWith('.xml')) slideCount++;
+    if (kind === 'xlsx' && f.path.startsWith('xl/worksheets/sheet') && f.path.endsWith('.xml')) sheetCount++;
+    if (kind === 'pptx' && f.path.startsWith('ppt/slides/') && f.path.endsWith('.xml')) {
+      const txt = (await f.buffer()).toString('utf-8');
+      if (/a:descr="[^"]+"/.test(txt)) hasAltTextHints = true;
     }
   }
-  return { hasCoreProps: hasCore, imageRelCount };
+  return { title, creator, subject, slideCount, sheetCount, hasAltTextHints };
 }
 
-/** Basic CSV/TXT heuristics: UTF-8, line endings, delimiter consistency. */
+/** Basic CSV/TXT heuristics: encoding and delimiter detection. */
 export function analyzeCsvTxt(buf: Buffer) {
-  const text = buf.toString('utf8');
-  const encodingOk = !text.includes('\uFFFD');
+  let encoding = 'utf-8';
+  let text = buf.toString('utf8');
+  if (text.includes('\uFFFD')) {
+    encoding = 'unknown';
+    text = buf.toString('latin1');
+  }
   const lines = text.split(/\r\n|\n/);
-  const lineEndingsOk = !(text.includes('\r') && text.includes('\n') && !text.includes('\r\n'));
   const first = lines[0] || '';
-  const delimiter = detectDelimiter(first);
+  const { delimiter, confidence } = detectDelimiter(first);
   let consistent = true;
   if (delimiter) {
     const count = first.split(delimiter).length;
@@ -51,13 +65,15 @@ export function analyzeCsvTxt(buf: Buffer) {
       if (l.split(delimiter).length !== count) { consistent = false; break; }
     }
   }
-  return { encodingOk, lineEndingsOk, delimiter, delimiterConsistent: consistent };
+  return { encoding, delimiter, delimiterConsistent: consistent, delimiterConfidence: confidence };
 }
 
-export function detectDelimiter(line: string): string {
-  if (line.includes(';')) return ';';
-  if (line.includes('\t')) return '\t';
-  if (line.includes(',')) return ',';
-  return '';
+export function detectDelimiter(line: string): { delimiter: string; confidence: number } {
+  const candidates: Record<string, number> = { ';': 0, ',': 0, '\t': 0 };
+  for (const d of Object.keys(candidates)) candidates[d] = (line.match(new RegExp(d === '\\t' ? '\\t' : d, 'g')) || []).length;
+  const entries = Object.entries(candidates).sort((a, b) => b[1] - a[1]);
+  const [delim, count] = entries[0];
+  const confidence = line.length ? count / line.length : 0;
+  return { delimiter: count > 0 ? (delim === '\\t' ? '\t' : delim) : '', confidence };
 }
 

--- a/backend/tests/downloads.e2e.test.ts
+++ b/backend/tests/downloads.e2e.test.ts
@@ -37,7 +37,7 @@ test('downloads module discovers and reports files', async (t) => {
     const resJson = JSON.parse(await fs.readFile(path.join('out', 'results.json'), 'utf-8'));
     assert.ok(resJson.modules.downloads.stats.total >= 2);
     const issues = JSON.parse(await fs.readFile(path.join('out', 'issues.json'), 'utf-8'));
-    assert.ok(issues.some((i: any) => /^pdf:|^csv:/.test(i.id)));
+    assert.ok(issues.some((i: any) => /^downloads:/.test(i.id)));
     await buildReports();
     const report = await fs.readFile(path.join('out', 'report_internal.html'), 'utf-8');
     assert.ok(/Pr\u00fcfung von Downloads/.test(report) && !/Keine pr\u00fcfbaren Downloads/.test(report));

--- a/backend/tests/downloads.test.ts
+++ b/backend/tests/downloads.test.ts
@@ -2,12 +2,13 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { analyzePdf, analyzeCsvTxt } from '../scanners/downloads.js';
 
-test('PDF tagging heuristic with and without StructTreeRoot', async () => {
-  const taggedBuf = Buffer.from('%PDF-1.4\n1 0 obj<< /StructTreeRoot 2 0 R /MarkInfo <</Marked true>> >>\nendobj\ntrailer<<>>\n%%EOF');
+test('PDF tagging and outline heuristics', async () => {
+  const taggedBuf = Buffer.from('%PDF-1.4\n1 0 obj<< /StructTreeRoot 2 0 R /Outlines 3 0 R /MarkInfo <</Marked true>> >>\nendobj\ntrailer<<>>\n%%EOF');
   const untaggedBuf = Buffer.from('%PDF-1.4\n1 0 obj<< /MarkInfo <</Marked true>> >>\nendobj\ntrailer<<>>\n%%EOF');
   const tagged = await analyzePdf(taggedBuf);
   const untagged = await analyzePdf(untaggedBuf);
   assert.equal(tagged.tagged, true);
+  assert.equal(tagged.hasOutline, true);
   assert.equal(untagged.tagged, false);
 });
 
@@ -16,5 +17,11 @@ test('CSV delimiter heuristic detects mismatch', () => {
   const res = analyzeCsvTxt(buf);
   assert.equal(res.delimiter, ',');
   assert.equal(res.delimiterConsistent, false);
+});
+
+test('CSV encoding detection flags non UTF-8', () => {
+  const buf = Buffer.from('\xff\xfea,b\x00', 'binary');
+  const res = analyzeCsvTxt(buf);
+  assert.equal(res.encoding, 'unknown');
 });
 


### PR DESCRIPTION
## Summary
- extend download scanner to extract richer metadata and flag missing info for PDFs, Office docs, and CSV/TXT files
- track per-type statistics and findings for download issues
- update tests for new download findings and heuristics

## Testing
- `node --test tests/downloads.test.ts`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_b_68b14b5dc7a0832cb1fe6e91d7010222